### PR TITLE
feat(docentes): Autocompletado y actualización de email en Alta Docente (#18) y actualización de .env.example 

### DIFF
--- a/.env.ejemplo
+++ b/.env.ejemplo
@@ -1,8 +1,8 @@
-APP_NAME=Laravel
-APP_ENV=local
-APP_KEY=base64:AGipomeY/yXiYC0Gh/I4EUYOWSS0m8Le0RJyZHPQF3g=
+APP_NAME="Sistema de gestión de profesorado para FP Virtual Aragón"
+APP_ENV=production
+APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost:9000
+APP_URL=https://gestionprof.fpvirtualaragon.es/
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
@@ -11,7 +11,7 @@ APP_FAKER_LOCALE=en_US
 APP_MAINTENANCE_DRIVER=file
 # APP_MAINTENANCE_STORE=database
 
-# PHP_CLI_SERVER_WORKERS=4
+PHP_CLI_SERVER_WORKERS=4
 
 BCRYPT_ROUNDS=12
 
@@ -21,13 +21,12 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 
-DB_CONNECTION=mysql
+DB_CONNECTION=mariadb
 DB_HOST=127.0.0.1
-DB_PORT=23306
-DB_DATABASE=instituto
-DB_USERNAME=alumno
-DB_PASSWORD=alumno
-DB_PASSWORD_ROOT=root12345
+DB_PORT=3306
+DB_DATABASE=gestor_profesores
+DB_USERNAME=root
+DB_PASSWORD=root 
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120

--- a/app/Http/Controllers/AltaDocenteController.php
+++ b/app/Http/Controllers/AltaDocenteController.php
@@ -34,7 +34,7 @@ class AltaDocenteController extends Controller
     {
         // 1. Validamos que el profesor esté y que haya al menos un módulo seleccionado
         $request->validate([
-            'dni' => 'required|string|max:10|unique:docentes,dni',
+            'dni' => 'required|string|max:10',
             'email' => 'required|email',
             'nombre' => 'required|string|max:255',
             'apellido' => 'required|string|max:255',
@@ -59,15 +59,9 @@ class AltaDocenteController extends Controller
                 },
             ],
 
-            //Comprueba si el email existe
             'email' => [
                 'required',
                 'email',
-                function ($attribute, $value, $fail) {
-                    if (CentroDocente::where('email', $value)->exists()) {
-                        $fail('Este correo electrónico ya está registrado.');
-                    }
-                },
             ],
 
             'nombre' => 'required|string|max:255',
@@ -106,7 +100,7 @@ class AltaDocenteController extends Controller
                 }
             }
             if ($docente) {
-                // Si el nombre o apellido han cambiado, actualizarlos
+                // Si el nombre, apellido o email han cambiado, actualizarlos
                 $nombreNuevo = $this->normalizarNombreYApellido($request->nombre);
                 $apellidoNuevo = $this->normalizarNombreYApellido($request->apellido);
 
@@ -119,6 +113,12 @@ class AltaDocenteController extends Controller
 
                 if ($docente->apellido !== $apellidoNuevo) {
                     $docente->apellido = $apellidoNuevo;
+                    $actualizado = true;
+                }
+
+                // Actualizar el email si el usuario lo ha corregido
+                if ($docente->email_virtual !== $request->email) {
+                    $docente->email_virtual = $request->email;
                     $actualizado = true;
                 }
 

--- a/resources/views/alta_docente.blade.php
+++ b/resources/views/alta_docente.blade.php
@@ -110,6 +110,7 @@
             const dniInput = document.getElementById('dni');
             const nombreInput = document.getElementById('nombre');
             const apellidoInput = document.getElementById('apellido');
+            const emailInput = document.getElementById('email');
             const toggleNombre = document.getElementById('toggle-nombre');
             const toggleApellido = document.getElementById('toggle-apellido');
 
@@ -175,8 +176,13 @@
                             toggleNombre.style.display = 'inline';
                             toggleApellido.style.display = 'inline';
 
-                            // Mostrar notificación bonita en lugar de alert
-                            showToast(`Datos autocompletados: ${data.nombre} ${data.apellido}`);
+                            // Rellenar el email con el valor actual de BD (editable por el usuario)
+                            if (data.email) {
+                                emailInput.value = data.email;
+                            }
+
+                            // Mostrar notificación con aviso de revisión de email
+                            showToast(`Docente encontrado. Revisa y corrige el email si es necesario.`);
                         } else {
                             [nombreInput, apellidoInput].forEach(input => {
                                 input.value = '';

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,17 +13,19 @@ use App\Http\Controllers\Admin\CentroController;
 
 Route::redirect('/', '/login');
 
-
+// Dashboard
 Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
+// Perfiles
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+// Docente
 Route::middleware(['auth'])->group(function () {
     Route::get('/alta-docente', [AltaDocenteController::class, 'create'])
         ->name('alta_docente');
@@ -35,8 +37,12 @@ Route::middleware(['auth'])->group(function () {
     // Cambiamos a POST para que sea más fácil de usar en botones simples
     Route::post('/docentes/baja/{dni}', [BajaDocenteController::class, 'destroy'])->name('docente.baja');
     Route::post('/docentes/reactivar/{dni}', [BajaDocenteController::class, 'reactivar'])->name('docente.reactivar');
+    
+    Route::get('/docentes/baja', [BajaDocenteController::class, 'index'])->name('docentes.index');
+    Route::delete('/docentes/baja/{dni}', [BajaDocenteController::class, 'destroy'])->name('docentes.destroy');
 });
 
+// Coordinador
 Route::middleware(['auth'])->group(function () {
     Route::get('/establecer-coordinador', [EstablecerCoordinadorController::class, 'index'])
         ->name('establecer_coordinador.index');
@@ -49,7 +55,7 @@ Route::middleware(['auth'])->group(function () {
 });
 
 
-
+// Tutor
 Route::middleware(['auth'])->group(function () {
     Route::get('/establecer-tutor', [EstablecerTutorController::class, 'index'])
         ->name('establecer_tutor.index');
@@ -61,6 +67,7 @@ Route::middleware(['auth'])->group(function () {
         ->name('tutor.destroy');
 });
 
+// Docencia
 Route::middleware(['auth'])->group(function () {
     Route::get('/establecer-docencia', [EstablecerDocenciaController::class, 'index'])
         ->name('establecer_docencia.index');
@@ -75,12 +82,8 @@ Route::middleware(['auth'])->group(function () {
 
 });
 
-Route::middleware(['auth'])->group(function () {
-    Route::get('/docentes/baja', [BajaDocenteController::class, 'index'])->name('docentes.index');
-    Route::delete('/docentes/baja/{dni}', [BajaDocenteController::class, 'destroy'])->name('docentes.destroy');
-});
 
-
+// Admin
 Route::middleware('web')->prefix('admin')->name('admin.')->group(function () {
     // Ruta /admin que muestra login si no está logueado, o redirige al dashboard si está autenticado
     Route::get('/', function () {

--- a/tests/Feature/GestionDocentesUpdateTest.php
+++ b/tests/Feature/GestionDocentesUpdateTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Models\Usuario;
+use App\Models\Centro;
+use App\Models\Docente;
+use App\Models\CentroDocente;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ============================================================
+// BLOQUE 1: Búsqueda de docente (endpoint AJAX)
+// GET /comprobar-docente/{dni}
+// ============================================================
+
+/** 7. AJAX - DNI existente devuelve datos correctos */
+test('GET /comprobar-docente devuelve nombre, apellido y email si el docente existe', function () {
+    $centro = Centro::forceCreate(['id_centro' => 'U100', 'nombre' => 'Centro Update Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'U100']);
+
+    Docente::forceCreate([
+        'dni'          => '22222222J',
+        'nombre'       => 'Laura',
+        'apellido'     => 'Sánchez Ramos',
+        'email_virtual' => 'laura@centro.com',
+    ]);
+
+    // Registrar también en centro_docente para que devuelva el email del centro
+    CentroDocente::forceCreate([
+        'dni'       => '22222222J',
+        'id_centro' => 'U100',
+        'email'     => 'laura@centro.com',
+    ]);
+
+    $response = $this->actingAs($usuario)->getJson('/comprobar-docente/22222222J');
+
+    $response->assertStatus(200)
+             ->assertJsonFragment([
+                 'existe'   => true,
+                 'nombre'   => 'Laura',
+                 'apellido' => 'Sánchez Ramos',
+                 'email'    => 'laura@centro.com',
+             ]);
+});
+
+/** 8. AJAX - DNI inexistente devuelve existe: false */
+test('GET /comprobar-docente devuelve existe false si el DNI no está registrado', function () {
+    $centro = Centro::forceCreate(['id_centro' => 'U101', 'nombre' => 'Centro Update Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'U101']);
+
+    $response = $this->actingAs($usuario)->getJson('/comprobar-docente/99988877X');
+
+    $response->assertStatus(200)
+             ->assertJsonFragment(['existe' => false]);
+});
+
+// ============================================================
+// BLOQUE 2: Actualización de correo (Upsert via store)
+// POST /alta-docente
+// ============================================================
+
+/** 9. UPSERT - Un DNI ya registrado no provoca error de validación */
+test('el store no devuelve error de validación cuando el DNI ya existe (upsert)', function () {
+    $centro = Centro::forceCreate(['id_centro' => 'U200', 'nombre' => 'Centro Update Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'U200']);
+
+    Docente::forceCreate([
+        'dni'           => '33333333P',
+        'nombre'        => 'Pedro',
+        'apellido'      => 'García López',
+        'email_virtual' => 'pedro@antiguo.com',
+    ]);
+
+    $datos = [
+        'dni'      => '33333333P',
+        'nombre'   => 'Pedro',
+        'apellido' => 'García López',
+        'email'    => 'pedro@nuevo.com',
+        'id_centro' => 'U200',
+    ];
+
+    $response = $this->actingAs($usuario)->post('/alta-docente', $datos);
+
+    // No debe haber errores de sesión por DNI duplicado
+    $response->assertSessionDoesntHaveErrors(['dni']);
+});
+
+/** 10. UPSERT - El email se actualiza correctamente en la base de datos */
+test('el store actualiza el email_virtual del docente cuando ya existe en BD', function () {
+    $centro = Centro::forceCreate(['id_centro' => 'U300', 'nombre' => 'Centro Update Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'U300']);
+
+    Docente::forceCreate([
+        'dni'           => '44444444W',
+        'nombre'        => 'Ana',
+        'apellido'      => 'Martínez Gil',
+        'email_virtual' => 'ana@viejo.com',
+    ]);
+
+    $datos = [
+        'dni'      => '44444444W',
+        'nombre'   => 'Ana',
+        'apellido' => 'Martínez Gil',
+        'email'    => 'ana@nuevo.com',
+        'id_centro' => 'U300',
+    ];
+
+    $this->actingAs($usuario)->post('/alta-docente', $datos);
+
+    $this->assertDatabaseHas('docentes', [
+        'dni'           => '44444444W',
+        'email_virtual' => 'ana@nuevo.com',
+    ]);
+});
+
+// ============================================================
+// BLOQUE 3: Integridad de datos
+// ============================================================
+
+/** 11. INTEGRIDAD - Actualizar un docente existente no duplica registros */
+test('actualizar un docente existente no incrementa el número de docentes en BD', function () {
+    $centro = Centro::forceCreate(['id_centro' => 'U400', 'nombre' => 'Centro Update Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'U400']);
+
+    Docente::forceCreate([
+        'dni'           => '55555555F',
+        'nombre'        => 'Carlos',
+        'apellido'      => 'Ruiz Mena',
+        'email_virtual' => 'carlos@viejo.com',
+    ]);
+
+    $totalAntes = Docente::count();
+
+    $datos = [
+        'dni'      => '55555555F',
+        'nombre'   => 'Carlos',
+        'apellido' => 'Ruiz Mena',
+        'email'    => 'carlos@nuevo.com',
+        'id_centro' => 'U400',
+    ];
+
+    $this->actingAs($usuario)->post('/alta-docente', $datos);
+
+    expect(Docente::count())->toBe($totalAntes);
+});


### PR DESCRIPTION
## ¿Qué problema resuelve?

Cuando se intentaba dar de alta un docente con un DNI ya registrado, el sistema 
bloqueaba el formulario con un error de validación (`unique:docentes,dni`), 
impidiendo actualizar datos como el correo electrónico.

## Cambios realizados

- **Controlador** `AltaDocenteController`: eliminada la regla `unique:docentes,dni` 
  y la validación de email único en `CentroDocente`. El método `store` ahora 
  actualiza `email_virtual` si el docente ya existe.
- **Vista** `alta_docente.blade.php`: el script AJAX rellena automáticamente 
  nombre, apellidos **y email** al detectar un DNI registrado. El campo email 
  permanece editable para que el usuario pueda corregirlo antes de guardar.
- **Tests** `GestionDocentesUpdateTest.php`: 5 tests Pest nuevos que cubren 
  el endpoint AJAX, el flujo upsert y la integridad de datos.

## Cómo probar

1. Ir a **Alta Docente**.
2. Introducir un DNI ya existente en la BD y salir del campo (blur).
3. Verificar que nombre, apellidos y email se rellenan automáticamente.
4. Modificar el email y pulsar **Guardar docente**.
5. Comprobar que el email se ha actualizado en la BD sin errores.

## Tests
<img width="980" height="288" alt="image" src="https://github.com/user-attachments/assets/3e9a6761-6ae0-40a3-b199-060623522d6e" />


Closes #18

## Configuración de Entorno (.env.example)
Se ha actualizado el archivo de ejemplo con las variables de entorno necesarias