### PR TITLE
Crear log del profesorado dado de baja #7

### DIFF
--- a/app/Console/Commands/EnviarResumenBajas.php
+++ b/app/Console/Commands/EnviarResumenBajas.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Log;
+use App\Mail\ResumenBajasDocentes;
+use Carbon\Carbon;
+
+class EnviarResumenBajas extends Command
+{
+    /**
+     * Nombre y firma del comando Artisan.
+     *
+     * @var string
+     */
+    protected $signature = 'docentes:enviar-resumen-bajas
+                            {--dry-run : Muestra el resumen por consola sin enviar email ni rotar el log}';
+
+    /**
+     * Descripción del comando.
+     *
+     * @var string
+     */
+    protected $description = 'Envía un informe semanal con las bajas de docentes registradas en docentes_baja.log';
+
+    /**
+     * Ejecuta el comando.
+     */
+    public function handle(): int
+    {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // ── 1. Verificar que el fichero de log existe ────────────────────────
+        if (! file_exists($logPath)) {
+            $this->warn('El fichero docentes_baja.log no existe. No hay bajas que reportar.');
+            Log::channel('bajas_docentes')->info('Resumen semanal: no se encontró el fichero de log.');
+            return self::SUCCESS;
+        }
+
+        // ── 2. Leer líneas de la última semana ───────────────────────────────
+        $desde     = Carbon::now()->subWeek();
+        $lineas    = file($logPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $registros = $this->filtrarUltimaSemana($lineas, $desde);
+
+        if (empty($registros)) {
+            $this->info('No se encontraron bajas en los últimos 7 días. No se enviará email.');
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Se encontraron %d registros de la última semana.', count($registros)));
+
+        // ── 3. Modo dry-run: solo mostrar en consola ─────────────────────────
+        if ($this->option('dry-run')) {
+            $this->line('--- MODO DRY-RUN: resumen de bajas ---');
+            foreach ($registros as $linea) {
+                $this->line($linea);
+            }
+            $this->info('Dry-run completado. No se envió email ni se rotó el log.');
+            return self::SUCCESS;
+        }
+
+        // ── 4. Enviar email con el resumen ───────────────────────────────────
+        $destinatario = config('mail.from.address');
+        $alertTo      = env('LOG_ALERT_TO', $destinatario);
+
+        try {
+            Mail::to($alertTo)->send(new ResumenBajasDocentes($registros, $desde));
+            $this->info("Informe enviado correctamente a: {$alertTo}");
+        } catch (\Exception $e) {
+            $this->error('Error al enviar el email: ' . $e->getMessage());
+            Log::channel('bajas_docentes')->error('Error al enviar resumen semanal de bajas', [
+                'error' => $e->getMessage(),
+            ]);
+            return self::FAILURE;
+        }
+
+        // ── 5. Rotar el log (truncar) tras el envío ──────────────────────────
+        $this->rotarLog($logPath, $registros);
+        $this->info('Log rotado correctamente.');
+
+        Log::channel('bajas_docentes')->info('Resumen semanal enviado y log rotado', [
+            'registros_enviados' => count($registros),
+            'destinatario'       => $alertTo,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Métodos privados
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Filtra las líneas del log que pertenecen a la última semana.
+     * El formato de timestamp de Monolog es: [YYYY-MM-DD HH:MM:SS]
+     *
+     * @param  array<string>  $lineas
+     * @param  Carbon         $desde
+     * @return array<string>
+     */
+    private function filtrarUltimaSemana(array $lineas, Carbon $desde): array
+    {
+        return array_filter($lineas, function (string $linea) use ($desde): bool {
+            // Extraer timestamp del formato Monolog: [2025-01-15 08:00:00]
+            if (preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]/', $linea, $matches)) {
+                try {
+                    $fecha = Carbon::createFromFormat('Y-m-d H:i:s', $matches[1]);
+                    return $fecha->greaterThanOrEqualTo($desde);
+                } catch (\Exception) {
+                    return false;
+                }
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Rota el log: las líneas antiguas (enviadas) se eliminan y se conserva
+     * el resto del fichero (líneas más nuevas que podrían haber llegado
+     * mientras se ejecutaba el comando).
+     *
+     * @param  string         $logPath
+     * @param  array<string>  $registrosEnviados
+     */
+    private function rotarLog(string $logPath, array $registrosEnviados): void
+    {
+        try {
+            // Releer el fichero por si se añadieron líneas durante la ejecución
+            $todasLasLineas = file($logPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+
+            // Conservar solo las líneas NO enviadas (más nuevas que la ventana)
+            $lineasEnviadas = array_values($registrosEnviados);
+            $resto          = array_diff($todasLasLineas, $lineasEnviadas);
+
+            file_put_contents($logPath, implode(PHP_EOL, $resto) . (count($resto) ? PHP_EOL : ''));
+        } catch (\Exception $e) {
+            $this->warn('No se pudo rotar el log: ' . $e->getMessage());
+            Log::channel('bajas_docentes')->warning('No se pudo rotar el log tras el envío del resumen', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Http/Controllers/BajaDocenteController.php
+++ b/app/Http/Controllers/BajaDocenteController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Docente;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use App\Models\Tutor;
 use App\Models\Coordinador;
 use App\Models\Docencia;
@@ -92,13 +93,30 @@ class BajaDocenteController extends Controller
             $docente->de_baja = true;
             $docente->save();
 
-
-
             DB::commit();
+
+            // --- Auditoría: registrar la baja en el canal dedicado ---
+            Log::channel('bajas_docentes')->info('Baja de docente procesada', [
+                'dni_docente'  => $dniUpper,
+                'nombre'       => $docente->nombre . ' ' . $docente->apellido,
+                'usuario_id'   => Auth::id(),
+                'usuario_name' => Auth::user()->name ?? Auth::user()->email ?? 'desconocido',
+                'id_centro'    => $idCentro,
+                'ip'           => request()->ip(),
+            ]);
 
             return redirect()->route('docentes.index')->with('success', 'Docente dado de baja correctamente.');
         } catch (\Exception $e) {
             DB::rollBack();
+
+            // --- Auditoría: error crítico al dar de baja ---
+            Log::channel('bajas_docentes')->critical('Error al dar de baja al docente', [
+                'dni_docente' => strtoupper($dni),
+                'usuario_id'  => Auth::id(),
+                'id_centro'   => $idCentro ?? null,
+                'error'       => $e->getMessage(),
+            ]);
+
             return redirect()->route('docentes.index')
                 ->withErrors(['error' => 'Error al dar de baja al docente: ' . $e->getMessage()]);
         }
@@ -120,11 +138,27 @@ class BajaDocenteController extends Controller
 
             DB::commit();
 
+            // --- Auditoría: registrar la reactivación en el canal dedicado ---
+            Log::channel('bajas_docentes')->notice('Docente reactivado', [
+                'dni_docente'  => $dniUpper,
+                'nombre'       => $docente->nombre . ' ' . $docente->apellido,
+                'usuario_id'   => Auth::id(),
+                'usuario_name' => Auth::user()->name ?? Auth::user()->email ?? 'desconocido',
+                'ip'           => request()->ip(),
+            ]);
+
             return redirect()->route('docentes.index')
                 ->with('success', "El docente {$docente->nombre} ha sido reactivado y ya puede acceder al sistema.");
 
         } catch (\Exception $e) {
             DB::rollBack();
+
+            Log::channel('bajas_docentes')->error('Error al reactivar docente', [
+                'dni_docente' => strtoupper($dni),
+                'usuario_id'  => Auth::id(),
+                'error'       => $e->getMessage(),
+            ]);
+
             return redirect()->route('docentes.index')
                 ->withErrors(['error' => 'Error al reactivar al docente: ' . $e->getMessage()]);
         }

--- a/app/Mail/ResumenBajasDocentes.php
+++ b/app/Mail/ResumenBajasDocentes.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mail;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ResumenBajasDocentes extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  array<string>  $registros  Líneas del log de la última semana
+     * @param  Carbon         $desde      Fecha de inicio del período
+     */
+    public function __construct(
+        public readonly array  $registros,
+        public readonly Carbon $desde,
+    ) {}
+
+    /**
+     * Configura el sobre del email (asunto, remitente, etc.).
+     */
+    public function envelope(): Envelope
+    {
+        $hasta = Carbon::now()->format('d/m/Y');
+        $desdeFormato = $this->desde->format('d/m/Y');
+
+        return new Envelope(
+            subject: "[Gestión Docentes] Informe semanal de bajas ({$desdeFormato} – {$hasta})",
+        );
+    }
+
+    /**
+     * Configura el contenido del email (vista Blade).
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.resumen_bajas_docentes',
+        );
+    }
+
+    /**
+     * Archivos adjuntos (ninguno en este caso).
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -3,6 +3,7 @@
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Handler\NativeMailerHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
@@ -125,6 +126,51 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Canal: bajas_docentes
+        |----------------------------------------------------------------------
+        | Registra exclusivamente las bajas de docentes en un fichero dedicado.
+        | Uso: Log::channel('bajas_docentes')->info(...)
+        */
+        'bajas_docentes' => [
+            'driver' => 'single',
+            'path'   => storage_path('logs/docentes_baja.log'),
+            'level'  => 'info',
+            'replace_placeholders' => true,
+        ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Canal: critical_mail
+        |----------------------------------------------------------------------
+        | Envía por correo electrónico todos los eventos de nivel critical o
+        | superior. Requiere que MAIL_* esté correctamente configurado en .env.
+        */
+        'critical_mail' => [
+            'driver'  => 'monolog',
+            'level'   => 'critical',
+            'handler' => NativeMailerHandler::class,
+            'handler_with' => [
+                'to'      => env('LOG_ALERT_TO', env('MAIL_FROM_ADDRESS', 'admin@example.com')),
+                'subject' => '[' . env('APP_NAME', 'Laravel') . '] ALERTA CRÍTICA',
+                'from'    => env('MAIL_FROM_ADDRESS', 'no-reply@example.com'),
+            ],
+        ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Stack: alertas
+        |----------------------------------------------------------------------
+        | Stack que agrupa el canal single estándar más el canal de email para
+        | errores críticos. Actívalo con LOG_STACK=single,critical_mail en .env.
+        */
+        'alertas' => [
+            'driver'   => 'stack',
+            'channels' => ['single', 'critical_mail'],
+            'ignore_exceptions' => false,
         ],
 
     ],

--- a/resources/views/emails/resumen_bajas_docentes.blade.php
+++ b/resources/views/emails/resumen_bajas_docentes.blade.php
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Informe Semanal de Bajas de Docentes</title>
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            background-color: #f4f6f9;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 700px;
+            margin: 30px auto;
+            background: #ffffff;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #1a3a5c;
+            color: #ffffff;
+            padding: 24px 32px;
+        }
+        .header h1 {
+            margin: 0;
+            font-size: 20px;
+            font-weight: 700;
+        }
+        .header p {
+            margin: 6px 0 0;
+            font-size: 13px;
+            opacity: 0.8;
+        }
+        .body {
+            padding: 28px 32px;
+        }
+        .summary-box {
+            background: #eef3f9;
+            border-left: 4px solid #1a3a5c;
+            padding: 14px 18px;
+            border-radius: 4px;
+            margin-bottom: 24px;
+        }
+        .summary-box p {
+            margin: 0;
+            font-size: 14px;
+        }
+        .summary-box strong {
+            color: #1a3a5c;
+        }
+        h2 {
+            font-size: 15px;
+            color: #1a3a5c;
+            margin: 0 0 12px;
+            border-bottom: 1px solid #dde4ed;
+            padding-bottom: 8px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 12px;
+            margin-bottom: 24px;
+        }
+        th {
+            background-color: #1a3a5c;
+            color: #fff;
+            text-align: left;
+            padding: 8px 10px;
+            font-weight: 600;
+        }
+        td {
+            padding: 8px 10px;
+            border-bottom: 1px solid #e8edf3;
+            vertical-align: top;
+        }
+        tr:nth-child(even) td {
+            background-color: #f7f9fc;
+        }
+        .badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .badge-info     { background: #d1ecf1; color: #0c5460; }
+        .badge-notice   { background: #d4edda; color: #155724; }
+        .badge-error    { background: #f8d7da; color: #721c24; }
+        .badge-critical { background: #6c1a1a; color: #fff; }
+        .raw-log {
+            background: #1e2a38;
+            color: #c8d8e8;
+            font-family: 'Courier New', monospace;
+            font-size: 11px;
+            padding: 16px;
+            border-radius: 6px;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+            margin-bottom: 24px;
+        }
+        .footer {
+            background: #f4f6f9;
+            color: #888;
+            font-size: 11px;
+            padding: 16px 32px;
+            text-align: center;
+            border-top: 1px solid #dde4ed;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+
+    {{-- ── Cabecera ─────────────────────────────────────────────────────── --}}
+    <div class="header">
+        <h1>📋 Informe Semanal de Bajas de Docentes</h1>
+        <p>
+            Período: {{ $desde->format('d/m/Y') }} – {{ now()->format('d/m/Y') }}
+            &nbsp;|&nbsp;
+            Generado el {{ now()->format('d/m/Y \a \l\a\s H:i') }}
+        </p>
+    </div>
+
+    <div class="body">
+
+        {{-- ── Resumen ejecutivo ───────────────────────────────────────────── --}}
+        <div class="summary-box">
+            <p>
+                Se han registrado <strong>{{ count($registros) }} evento(s)</strong>
+                en el sistema de auditoría de bajas durante los últimos 7 días.
+            </p>
+        </div>
+
+        {{-- ── Tabla de registros parseados ───────────────────────────────── --}}
+        @php
+            $parsed = collect($registros)->map(function (string $linea): array {
+                $timestamp = '';
+                $canal     = '';
+                $nivel     = 'info';
+                $mensaje   = $linea;
+                $contexto  = '';
+
+                // Formato Monolog: [2025-01-15 08:00:00] canal.NIVEL: mensaje {"key":"value"}
+                if (preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]\s+(\S+)\.(\w+):\s+(.+?)(\s+\{.*\})?$/', $linea, $m)) {
+                    $timestamp = $m[1];
+                    $canal     = $m[2];
+                    $nivel     = strtolower($m[3]);
+                    $mensaje   = trim($m[4]);
+                    $contexto  = isset($m[5]) ? trim($m[5]) : '';
+                }
+
+                return compact('timestamp', 'canal', 'nivel', 'mensaje', 'contexto', 'linea');
+            });
+        @endphp
+
+        @if ($parsed->isNotEmpty())
+            <h2>Detalle de eventos</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Fecha / Hora</th>
+                        <th>Nivel</th>
+                        <th>Mensaje</th>
+                        <th>Contexto</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($parsed as $reg)
+                        <tr>
+                            <td>{{ $reg['timestamp'] ?: '—' }}</td>
+                            <td>
+                                @php
+                                    $badge = match($reg['nivel']) {
+                                        'notice'   => 'badge-notice',
+                                        'error'    => 'badge-error',
+                                        'critical' => 'badge-critical',
+                                        default    => 'badge-info',
+                                    };
+                                @endphp
+                                <span class="badge {{ $badge }}">{{ strtoupper($reg['nivel']) }}</span>
+                            </td>
+                            <td>{{ $reg['mensaje'] ?: $reg['linea'] }}</td>
+                            <td>
+                                @if ($reg['contexto'])
+                                    <small>{{ $reg['contexto'] }}</small>
+                                @else
+                                    —
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+
+        {{-- ── Log en bruto (fallback legible) ───────────────────────────── --}}
+        <h2>Log completo del período</h2>
+        <div class="raw-log">{{ implode("\n", $registros) }}</div>
+
+    </div>
+
+    {{-- ── Pie de página ───────────────────────────────────────────────── --}}
+    <div class="footer">
+        Este mensaje ha sido generado automáticamente por el sistema de gestión de docentes
+        ({{ config('app.name') }}) el {{ now()->format('d/m/Y \a \l\a\s H:i') }}.
+        No responda a este correo.
+    </div>
+
+</div>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,35 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
+// ─── Comando de demostración incluido por defecto ────────────────────────────
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// ─── Tarea programada: Informe semanal de bajas de docentes ──────────────────
+// Se ejecuta todos los lunes a las 08:00 AM.
+// Envía por email el resumen de bajas registradas en docentes_baja.log
+// y rota el log tras el envío para evitar duplicados.
+//
+// Para probar manualmente:
+//   php artisan docentes:enviar-resumen-bajas
+//   php artisan docentes:enviar-resumen-bajas --dry-run
+//
+// Para ejecutar el scheduler en desarrollo:
+//   php artisan schedule:work
+//
+Schedule::command('docentes:enviar-resumen-bajas')
+    ->weeklyOn(1, '08:00')          // 1 = lunes, a las 08:00
+    ->timezone('Europe/Madrid')
+    ->withoutOverlapping()          // evita ejecuciones solapadas
+    ->runInBackground()
+    ->onSuccess(function () {
+        \Illuminate\Support\Facades\Log::channel('bajas_docentes')
+            ->info('Scheduler: tarea semanal completada correctamente.');
+    })
+    ->onFailure(function () {
+        \Illuminate\Support\Facades\Log::channel('bajas_docentes')
+            ->critical('Scheduler: la tarea semanal de bajas FALLÓ.');
+    });

--- a/tests/Feature/BajasDocentesLogTest.php
+++ b/tests/Feature/BajasDocentesLogTest.php
@@ -1,0 +1,506 @@
+<?php
+
+/**
+ * Suite de tests — Issue #7: Auditoría y Notificaciones de Bajas de Docentes
+ *
+ * Cubre:
+ *   A) Escritura de logs en el canal bajas_docentes (integración real con fichero físico)
+ *   B) Comando Artisan docentes:enviar-resumen-bajas (Mail::fake + rotación de log)
+ *   C) Casos límite y protecciones del comando
+ *
+ * Estrategia para logs:
+ *   - El canal 'bajas_docentes' escribe en storage/logs/docentes_baja.log (driver single).
+ *   - En los tests de BLOQUE A verificamos el fichero físico directamente con file_get_contents().
+ *     Esto no requiere ninguna dependencia extra (como timacdonald/log-fake).
+ *   - En los tests de BLOQUE B usamos Mail::fake() para interceptar envíos de correo.
+ *
+ * NOTA: Si en el futuro se instala `timacdonald/log-fake` (composer require --dev timacdonald/log-fake),
+ * los tests del Bloque A pueden migrarse a usar LogFake::bind() y Log::channel('bajas_docentes')->assertLogged().
+ *
+ * Ejecución:
+ *   ./vendor/bin/pest tests/Feature/BajasDocentesLogTest.php --no-coverage
+ */
+
+use App\Mail\ResumenBajasDocentes;
+use App\Models\Centro;
+use App\Models\Docente;
+use App\Models\Usuario;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Mail;
+
+// ─── Ruta física del log de bajas ────────────────────────────────────────────
+it('escribe en el log', function () {
+    $path = storage_path('logs/docentes_baja.log');
+
+// ─── Helper: línea de log con timestamp RECIENTE (formato Monolog) ───────────
+function logLineReciente(string $nivel = 'INFO', string $mensaje = 'Baja de docente procesada'): string
+{
+    $ts = Carbon::now()->format('Y-m-d H:i:s');
+    return "[{$ts}] bajas_docentes.{$nivel}: {$mensaje} {\"dni_docente\":\"12345678A\",\"usuario_id\":1}";
+}
+
+// ─── Helper: línea de log con timestamp ANTIGUO (>7 días) ────────────────────
+function logLineAntigua(string $nivel = 'INFO', string $mensaje = 'Baja antigua'): string
+{
+    $ts = Carbon::now()->subDays(10)->format('Y-m-d H:i:s');
+    return "[{$ts}] bajas_docentes.{$nivel}: {$mensaje} {\"dni_docente\":\"99999999Z\",\"usuario_id\":2}";
+}
+
+// ─── Setup / Teardown global: limpiar el fichero de log antes y después ──────
+beforeEach(function () {
+    $logPath = storage_path('logs/docentes_baja.log');
+    if (! is_dir(dirname($logPath))) {
+        mkdir(dirname($logPath), 0755, true);
+    }
+    // Fichero limpio para cada test (evita interferencias entre tests)
+    file_put_contents($logPath, '');
+});
+
+afterEach(function () {
+    $logPath = storage_path('logs/docentes_baja.log');
+    if (file_exists($logPath)) {
+        unlink($logPath);
+    }
+});
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE A — Escritura de logs en BajaDocenteController
+// Verificación mediante el fichero físico storage/logs/docentes_baja.log
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('A) Auditoría en BajaDocenteController', function () {
+
+    // ── A1: Baja exitosa → escribe entrada de nivel INFO ─────────────────────
+    test('dar de baja a un docente escribe una entrada INFO en docentes_baja.log', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA01', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA01']);
+        $docente = Docente::forceCreate([
+            'nombre'        => 'Ana',
+            'apellido'      => 'García',
+            'dni'           => 'LA000001A',
+            'email_virtual' => 'ana@test.com',
+            'de_baja'       => false,
+        ]);
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/baja/{$docente->dni}");
+
+        // Assert — el fichero debe existir y contener nivel INFO con el DNI correcto
+        expect(file_exists($logPath))->toBeTrue();
+
+        $contenido = file_get_contents($logPath);
+        expect($contenido)
+            ->toContain('Baja de docente procesada')
+            ->toContain('INFO')
+            ->toContain('LA000001A');
+    });
+
+    // ── A2: Baja exitosa → el log incluye el ID del usuario que actúa ────────
+    test('el log de baja incluye el ID del usuario autenticado', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA02', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA02']);
+        $docente = Docente::forceCreate([
+            'nombre'        => 'Carlos',
+            'apellido'      => 'López',
+            'dni'           => 'LA000002B',
+            'email_virtual' => 'carlos@test.com',
+            'de_baja'       => false,
+        ]);
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/baja/{$docente->dni}");
+
+        // Assert — el contexto JSON del log debe incluir el usuario_id
+        $contenido = file_get_contents($logPath);
+        expect($contenido)->toContain((string) $usuario->id);
+    });
+
+    // ── A3: Reactivación exitosa → escribe entrada de nivel NOTICE ───────────
+    test('reactivar un docente escribe una entrada NOTICE en docentes_baja.log', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA03', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA03']);
+        $docente = Docente::forceCreate([
+            'nombre'        => 'Pedro',
+            'apellido'      => 'Martínez',
+            'dni'           => 'LA000003C',
+            'email_virtual' => 'pedro@test.com',
+            'de_baja'       => true,
+        ]);
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/reactivar/{$docente->dni}");
+
+        // Assert
+        expect(file_exists($logPath))->toBeTrue();
+
+        $contenido = file_get_contents($logPath);
+        expect($contenido)
+            ->toContain('Docente reactivado')
+            ->toContain('NOTICE')
+            ->toContain('LA000003C');
+    });
+
+    // ── A4: Fallo de BD (DNI inexistente) → escribe nivel CRITICAL ───────────
+    test('un fallo al dar de baja escribe una entrada CRITICAL en docentes_baja.log', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA04', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA04']);
+
+        // DNI que no existe → firstOrFail() lanzará ModelNotFoundException
+        $dniInexistente = 'XX0099099Z';
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/baja/{$dniInexistente}");
+
+        // Assert — debe haberse escrito CRITICAL
+        expect(file_exists($logPath))->toBeTrue();
+
+        $contenido = file_get_contents($logPath);
+        expect($contenido)
+            ->toContain('CRITICAL')
+            ->toContain('Error al dar de baja')
+            ->toContain(strtoupper($dniInexistente));
+    });
+
+    // ── A5: Fallo al reactivar (DNI inexistente) → escribe nivel ERROR ───────
+    test('un fallo al reactivar escribe una entrada ERROR en docentes_baja.log', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA05', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA05']);
+        $dniInexistente = 'YY0088088X';
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/reactivar/{$dniInexistente}");
+
+        // Assert
+        $contenido = file_get_contents($logPath);
+        expect($contenido)
+            ->toContain('ERROR')
+            ->toContain('Error al reactivar')
+            ->toContain(strtoupper($dniInexistente));
+    });
+
+    // ── A6: Baja → el log usa el canal bajas_docentes, NO el canal general ───
+    test('la baja no escribe nada en el log general laravel.log', function () {
+        $logGeneral = storage_path('logs/laravel.log');
+        $contenidoAntes = file_exists($logGeneral) ? file_get_contents($logGeneral) : '';
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA06', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA06']);
+        $docente = Docente::forceCreate([
+            'nombre'        => 'Rafa',
+            'apellido'      => 'Sanz',
+            'dni'           => 'LA000006D',
+            'email_virtual' => 'rafa@test.com',
+            'de_baja'       => false,
+        ]);
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/baja/{$docente->dni}");
+
+        // Assert — el laravel.log NO debe tener nuevas entradas de baja de docente
+        $contenidoDespues = file_exists($logGeneral) ? file_get_contents($logGeneral) : '';
+        $lineasNuevas     = str_replace($contenidoAntes, '', $contenidoDespues);
+        expect($lineasNuevas)->not->toContain('Baja de docente procesada');
+    });
+
+    // ── A7: Múltiples bajas → cada una genera su propia entrada en el log ─────
+    test('dar de baja a dos docentes genera dos entradas en docentes_baja.log', function () {
+        $logPath = storage_path('logs/docentes_baja.log');
+
+        // Arrange
+        $centro  = Centro::forceCreate(['id_centro' => 'LA07', 'nombre' => 'Centro Log Test']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LA07']);
+        $doc1    = Docente::forceCreate(['nombre' => 'D1', 'apellido' => 'A', 'dni' => 'LA000007E', 'email_virtual' => 'd1@test.com', 'de_baja' => false]);
+        $doc2    = Docente::forceCreate(['nombre' => 'D2', 'apellido' => 'B', 'dni' => 'LA000007F', 'email_virtual' => 'd2@test.com', 'de_baja' => false]);
+
+        // Act
+        $this->actingAs($usuario)->post("/docentes/baja/{$doc1->dni}");
+        $this->actingAs($usuario)->post("/docentes/baja/{$doc2->dni}");
+
+        // Assert — el fichero debe contener ambos DNIs
+        $contenido = file_get_contents($logPath);
+        expect($contenido)
+            ->toContain('LA000007E')
+            ->toContain('LA000007F');
+
+        // Y debe haber al menos 2 líneas de log
+        $lineas = array_filter(explode(PHP_EOL, trim($contenido)));
+        expect(count($lineas))->toBeGreaterThanOrEqual(2);
+    });
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE B — Comando Artisan: docentes:enviar-resumen-bajas
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('B) Comando docentes:enviar-resumen-bajas', function () {
+
+    // ── B1: Con registros recientes → envía ResumenBajasDocentes ─────────────
+    test('el comando envía el mailable ResumenBajasDocentes cuando hay registros recientes', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, 1);
+    });
+
+    // ── B2: El Mailable recibe exactamente los registros del log ─────────────
+    test('el mailable recibe los registros extraídos del log de la última semana', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        $linea   = logLineReciente('INFO', 'Baja de docente procesada');
+        file_put_contents($logPath, $linea . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, function (ResumenBajasDocentes $mail) use ($linea) {
+            return in_array($linea, $mail->registros, strict: true);
+        });
+    });
+
+    // ── B3: El Mailable recibe una instancia Carbon correcta como $desde ──────
+    test('el mailable recibe una instancia Carbon como fecha de inicio del período', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+        $antes = Carbon::now()->subWeek()->startOfMinute();
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, function (ResumenBajasDocentes $mail) use ($antes) {
+            return $mail->desde instanceof Carbon
+                && $mail->desde->greaterThanOrEqualTo($antes);
+        });
+    });
+
+    // ── B4: Tras el envío el fichero de log se vacía (rotación) ──────────────
+    test('después del envío exitoso docentes_baja.log queda vacío (rotación)', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        expect(file_exists($logPath))->toBeTrue();
+        expect(trim(file_get_contents($logPath)))->toContain('Resumen semanal enviado');
+    });
+
+    // ── B5: Líneas antiguas (>7 días) → el email NO se envía ─────────────────
+    test('el comando no envía email si solo hay registros de hace más de 7 días', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineAntigua() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')
+            ->expectsOutput('No se encontraron bajas en los últimos 7 días. No se enviará email.')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+    });
+
+    // ── B6: Líneas antiguas se conservan en el log tras la rotación ──────────
+    test('las líneas antiguas no se eliminan en la rotación, solo las enviadas', function () {
+        Mail::fake();
+        $logPath       = storage_path('logs/docentes_baja.log');
+        $lineaReciente = logLineReciente('INFO', 'Baja reciente');
+        $lineaAntigua  = logLineAntigua('INFO',  'Baja antigua');
+        file_put_contents($logPath, $lineaAntigua . PHP_EOL . $lineaReciente . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        $contenido = file_get_contents($logPath);
+        expect($contenido)->toContain($lineaAntigua);
+        expect($contenido)->not->toContain($lineaReciente);
+    });
+
+    // ── B7: --dry-run → no envía email ───────────────────────────────────────
+    test('con --dry-run el comando no envía ningún email', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas --dry-run')
+            ->expectsOutputToContain('Dry-run completado')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+    });
+
+    // ── B8: --dry-run → no modifica el fichero de log ────────────────────────
+    test('con --dry-run el fichero de log no es modificado', function () {
+        Mail::fake();
+        $logPath          = storage_path('logs/docentes_baja.log');
+        $linea            = logLineReciente();
+        file_put_contents($logPath, $linea . PHP_EOL);
+        $contenidoOriginal = file_get_contents($logPath);
+
+        $this->artisan('docentes:enviar-resumen-bajas --dry-run')->assertSuccessful();
+
+        expect(file_get_contents($logPath))->toBe($contenidoOriginal);
+    });
+
+    // ── B9: --dry-run → imprime las líneas por consola ───────────────────────
+    test('con --dry-run el comando imprime las líneas del log en la consola', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente('INFO', 'Baja de docente procesada') . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas --dry-run')
+            ->expectsOutputToContain('MODO DRY-RUN')
+            ->expectsOutputToContain('Baja de docente procesada')
+            ->assertSuccessful();
+    });
+
+    // ── B10: Solo se manda UN email por ejecución (no duplicados) ─────────────
+    test('el comando envía exactamente un email aunque haya muchos registros recientes', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        $lineas  = '';
+        for ($i = 0; $i < 15; $i++) {
+            $lineas .= logLineReciente('INFO', "Baja número {$i}") . PHP_EOL;
+        }
+        file_put_contents($logPath, $lineas);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, 1);
+    });
+
+    // ── B11: Múltiples registros → el Mailable los incluye todos ─────────────
+    test('cuando hay varios registros recientes todos se incluyen en el mailable', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        $lineas  = implode(PHP_EOL, [
+            logLineReciente('INFO',     'Baja de docente procesada'),
+            logLineReciente('NOTICE',   'Docente reactivado'),
+            logLineReciente('CRITICAL', 'Error al dar de baja al docente'),
+        ]) . PHP_EOL;
+        file_put_contents($logPath, $lineas);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, function (ResumenBajasDocentes $mail) {
+            return count($mail->registros) === 3;
+        });
+    });
+
+    // ── B12: Mezcla recientes + antiguas → Mailable solo lleva los recientes ──
+    test('solo se incluyen en el mailable los registros de los últimos 7 días', function () {
+        Mail::fake();
+        $logPath       = storage_path('logs/docentes_baja.log');
+        $lineaReciente = logLineReciente('INFO', 'Baja reciente');
+        $lineaAntigua  = logLineAntigua('INFO',  'Baja antigua');
+        file_put_contents($logPath, $lineaAntigua . PHP_EOL . $lineaReciente . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+
+        Mail::assertSent(ResumenBajasDocentes::class, function (ResumenBajasDocentes $mail) use ($lineaReciente, $lineaAntigua) {
+            return count($mail->registros) === 1
+                && in_array($lineaReciente, $mail->registros, strict: true)
+                && ! in_array($lineaAntigua, $mail->registros, strict: true);
+        });
+    });
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE C — Casos límite y protecciones del comando
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('C) Casos límite del comando', function () {
+
+    // ── C1: Fichero de log inexistente → éxito sin email ─────────────────────
+    test('el comando finaliza con éxito y no envía email si el fichero de log no existe', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        if (file_exists($logPath)) {
+            unlink($logPath);
+        }
+
+        $this->artisan('docentes:enviar-resumen-bajas')
+            ->expectsOutputToContain('no existe')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+    });
+
+    // ── C2: Fichero vacío → no se envía email ────────────────────────────────
+    test('el comando no envía email si el fichero de log está vacío', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, '');
+
+        $this->artisan('docentes:enviar-resumen-bajas')
+            ->expectsOutput('No se encontraron bajas en los últimos 7 días. No se enviará email.')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+    });
+
+    // ── C3: El comando devuelve código de salida 0 en el escenario normal ─────
+    test('el comando retorna exit code 0 cuando completa el envío con éxito', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+    });
+
+    // ── C4: El comando muestra cuántos registros se enviaron ──────────────────
+    test('el comando imprime en consola el número de registros encontrados', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL . logLineReciente() . PHP_EOL);
+
+        $this->artisan('docentes:enviar-resumen-bajas')
+            ->expectsOutputToContain('registros')
+            ->assertSuccessful();
+    });
+
+    // ── C5: El fichero de log se recrea en el siguiente ciclo ─────────────────
+    test('el fichero de log puede volver a recibir entradas después de la rotación', function () {
+        Mail::fake();
+        $logPath = storage_path('logs/docentes_baja.log');
+        file_put_contents($logPath, logLineReciente() . PHP_EOL);
+
+        // Primera ejecución → rota el log (queda vacío)
+        $this->artisan('docentes:enviar-resumen-bajas')->assertSuccessful();
+        expect(trim(file_get_contents($logPath)))->toContain('Resumen semanal enviado');
+
+        // Simula una nueva baja tras la rotación
+        $centro  = Centro::forceCreate(['id_centro' => 'LC05', 'nombre' => 'Centro Rotación']);
+        $usuario = Usuario::factory()->create(['id_centro' => 'LC05']);
+        $docente = Docente::forceCreate([
+            'nombre'        => 'Nueva',
+            'apellido'      => 'Baja',
+            'dni'           => 'LC000005G',
+            'email_virtual' => 'nueva@test.com',
+            'de_baja'       => false,
+        ]);
+        $this->actingAs($usuario)->post("/docentes/baja/{$docente->dni}");
+
+        // El fichero debe haber sido recreado con la nueva entrada
+        $contenido = file_get_contents($logPath);
+        expect($contenido)->toContain('LC000005G');
+    });
+});


### PR DESCRIPTION
## ¿Qué problema resuelve?
La falta de trazabilidad en las bajas y reactivaciones del profesorado. Hasta ahora, no había registro de qué administrador realizaba estos cambios ni cuándo, y la dirección no recibía ninguna notificación consolidada de estos movimientos, dificultando la auditoría del sistema.

## Cambios realizados
- **Configuración de Logs** `(config/logging.php)`: Creación de un canal específico llamado docentes_baja que redirige la auditoría a un archivo independiente `(storage/logs/docentes_baja.log)`.

- **Controlador** `BajaDocenteController.php`: Implementación de lógica de auditoría. Se registra el ID del usuario, la IP, el DNI del docente y la acción realizada (Baja/Reactivación) con niveles INFO, NOTICE y ERROR.

## Sistema de Notificaciones:

-**Mailable**: ResumenBajasDocentes para el informe semanal.

-**Comando Artisan**: docentes:enviar-resumen-bajas para filtrar registros recientes, enviar el mail y rotar el log.

-**Programación** `(routes/console.php)`: Registro en el Scheduler de Laravel para automatizar el envío y la limpieza.

## Cómo probar
-**Seguimiento en tiempo real**: Antes de tocar nada, abre una terminal y ejecuta:
`docker compose exec app-backend tail -f storage/logs/docentes_baja.log`

-**Acción en la Web**: Entra en la gestión de docentes y da de baja a un profesor. Verás aparecer la línea de auditoría al instante en la terminal anterior.

-**Envío Manual**: Fuerza el envío del resumen con:
`docker compose exec app-backend php artisan docentes:enviar-resumen-bajas`

-**Verificación de Rotación**: Tras el comando, comprueba que el archivo de log se ha vaciado o solo contiene la confirmación del envío.

## Tests
<img width="1389" height="697" alt="Captura de pantalla 2026-05-04 145421" src="https://github.com/user-attachments/assets/62861683-23c2-4835-ac10-4b221c7841f7" />


Closes #7