### PR TITLE
feat: Generación de correo institucional y vista de altas masivas #58 #60

### DIFF
--- a/app/Http/Controllers/Admin/AltaPlataformaController.php
+++ b/app/Http/Controllers/Admin/AltaPlataformaController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Docente;
+use Illuminate\Http\Request;
+
+class AltaPlataformaController extends Controller
+{
+    /**
+     * Listado de docentes pendientes/procesados para dar de alta en plataformas.
+     * Excluye los que están de baja y los que no tienen email_virtual aún.
+     */
+    public function index(Request $request)
+    {
+        $query = Docente::query()
+            ->where('de_baja', false)
+            ->whereNotNull('email_virtual')
+            ->where('email_virtual', '!=', '');
+
+        // Filtro por estado
+        if ($request->filled('estado')) {
+            if ($request->estado === 'pendiente') {
+                $query->where('is_procesado', false);
+            } elseif ($request->estado === 'procesado') {
+                $query->where('is_procesado', true);
+            }
+        }
+
+        // Búsqueda por nombre, apellido o DNI
+        if ($request->filled('buscar')) {
+            $buscar = $request->buscar;
+            $query->where(function ($q) use ($buscar) {
+                $q->where('nombre', 'like', "%{$buscar}%")
+                  ->orWhere('apellido', 'like', "%{$buscar}%")
+                  ->orWhere('dni', 'like', "%{$buscar}%");
+            });
+        }
+
+        $docentes = $query->clone()->orderBy('apellido')->orderBy('nombre')->paginate(20)->withQueryString();
+
+        // Embed all docente data as JSON for client-side CSV generation
+        // Use clone() so paginate()'s LIMIT/OFFSET don't bleed into this query
+        $docentesJson = $query->clone()->orderBy('apellido')->orderBy('nombre')->get()->map(function ($d) {
+            return [
+                'id'            => $d->id,
+                'dni'           => $d->dni,
+                'nombre'        => $d->nombre,
+                'apellido'      => $d->apellido,
+                'email_virtual' => $d->email_virtual,
+                'is_procesado'  => $d->is_procesado,
+                'fecha_procesado' => $d->fecha_procesado?->format('d/m/Y H:i'),
+            ];
+        });
+
+        return view('admin.alta_plataforma', compact('docentes', 'docentesJson'));
+    }
+
+    /**
+     * AJAX — Previsualización de la línea CSV para un docente.
+     */
+    public function preview(int $id)
+    {
+        $docente = Docente::findOrFail($id);
+
+        $local = explode('@', $docente->email_virtual)[0] ?? $docente->email_virtual;
+
+        return response()->json([
+            'dni'           => $docente->dni,
+            'nombre'        => $docente->nombre,
+            'apellido'      => $docente->apellido,
+            'email_virtual' => $docente->email_virtual,
+            'google_csv'    => implode(',', [
+                $docente->nombre . ' ' . $docente->apellido,
+                $docente->email_virtual,
+                '',  // Password (vacío — se generará)
+                '',  // Org unit
+            ]),
+            'moodle_csv'    => implode(',', [
+                '"prof' . $docente->dni . '"',  // username
+                '"' . $docente->nombre . '"',   // firstname (nombre_normalizado)
+                '"' . $docente->apellido . '"', // lastname (apellido_normalizado)
+                '"' . $docente->email_virtual . '"', // email
+            ]),
+        ]);
+    }
+
+    /**
+     * Marcar los docentes seleccionados como procesados.
+     */
+    public function procesarAltas(Request $request)
+    {
+        $request->validate([
+            'ids'   => 'required|array|min:1',
+            'ids.*' => 'integer|exists:docentes,id',
+        ]);
+
+        Docente::whereIn('id', $request->ids)
+            ->where('de_baja', false)
+            ->update([
+                'is_procesado'   => true,
+                'fecha_procesado' => now(),
+            ]);
+
+        return response()->json(['ok' => true, 'procesados' => count($request->ids)]);
+    }
+}

--- a/app/Http/Controllers/AltaDocenteController.php
+++ b/app/Http/Controllers/AltaDocenteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Docente;
+use App\Services\GeneradorEmailVirtualService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Auth;
@@ -10,9 +11,10 @@ use App\Models\CentroDocente;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
-
 class AltaDocenteController extends Controller
 {
+    public function __construct(private GeneradorEmailVirtualService $emailService) {}
+
     public function create()
     {
         $centro = Auth::user()->centro;
@@ -22,30 +24,48 @@ class AltaDocenteController extends Controller
     /**
      * Normaliza nombres quitando caracteres prohibidos y poniendo mayúsculas.
      */
-    private function normalizarNombreYApellido($string) {
-        // Primero eliminamos los caracteres "º" y "."
+    private function normalizarNombreYApellido(string $string): string
+    {
         $limpio = str_replace(['º', '.'], '', $string);
-
         return mb_convert_case(mb_strtolower($limpio, 'UTF-8'), MB_CASE_TITLE, 'UTF-8');
     }
 
+    /**
+     * AJAX — Previsualización del email @fpvirtualaragon.es sin resolver colisiones.
+     * GET /alta-docente/preview-email?nombre=X&apellido=Y
+     */
+    public function previewEmail(Request $request)
+    {
+        $nombre   = trim($request->input('nombre', ''));
+        $apellido = trim($request->input('apellido', ''));
+
+        if (empty($nombre) || empty($apellido)) {
+            return response()->json(['email' => null]);
+        }
+
+        $nombreNorm   = $this->normalizarNombreYApellido($nombre);
+        $apellidoNorm = $this->normalizarNombreYApellido($apellido);
+
+        return response()->json([
+            'email' => $this->emailService->previsualizarEmail($nombreNorm, $apellidoNorm),
+        ]);
+    }
 
     public function store(Request $request)
     {
-        // 1. Validamos que el profesor esté y que haya al menos un módulo seleccionado
+        // ── Validación básica ─────────────────────────────────────────────
         $request->validate([
-            'dni' => 'required|string|max:10',
-            'email' => 'required|email',
-            'nombre' => 'required|string|max:255',
-            'apellido' => 'required|string|max:255',
-            'id_centro' => 'required'
+            'dni'       => 'required|string|max:10',
+            'email'     => 'required|email',
+            'nombre'    => 'required|string|max:255',
+            'apellido'  => 'required|string|max:255',
+            'id_centro' => 'required',
         ]);
 
         $dni = strtoupper($request->dni);
 
-
         $validator = Validator::make($request->all(), [
-           'dni' => [
+            'dni' => [
                 'required',
                 'string',
                 'max:10',
@@ -58,20 +78,13 @@ class AltaDocenteController extends Controller
                     }
                 },
             ],
-
-            'email' => [
-                'required',
-                'email',
-            ],
-
-            'nombre' => 'required|string|max:255',
-            'apellido' => 'required|string|max:255',
+            'email'     => ['required', 'email'],
+            'nombre'    => 'required|string|max:255',
+            'apellido'  => 'required|string|max:255',
             'id_centro' => 'required|string',
-            // TAREA E: Validamos el nuevo campo de formación
             'formacion' => 'nullable|boolean',
         ]);
 
-        //Si da algun error
         if ($validator->fails()) {
             return redirect()->back()->withErrors($validator)->withInput();
         }
@@ -79,132 +92,125 @@ class AltaDocenteController extends Controller
         DB::beginTransaction();
 
         try {
-            // Buscar el docente existente por DNI
             $docente = Docente::where('dni', $dni)->first();
 
-            // 2. ASIGNACIÓN MASIVA DE MÓDULOS
-            // Primero borramos las asignaciones antiguas para no duplicar (si es necesario)
-        DB::table('docente_modulo_ciclo')->where('dni', $dni)->delete();
-            // Luego insertamos cada módulo seleccionado
+            // ── Módulos ───────────────────────────────────────────────────
+            DB::table('docente_modulo_ciclo')->where('dni', $dni)->delete();
             if ($request->has('modulos')) {
-                // Obtenemos el ID del centro del usuario logueado para que sea automático
-                $id_centro = Auth::user()->centro->id_centro;
                 foreach ($request->modulos as $id_modulo) {
-
                     DB::table('docente_modulo_ciclo')->insert([
-                        'dni' => strtoupper($dni),
-                        'id_modulo' => $id_modulo,
+                        'dni'        => strtoupper($dni),
+                        'id_modulo'  => $id_modulo,
                         'created_at' => now(),
                         'updated_at' => now(),
                     ]);
                 }
             }
-            if ($docente) {
-                // Si el nombre, apellido o email han cambiado, actualizarlos
-                $nombreNuevo = $this->normalizarNombreYApellido($request->nombre);
-                $apellidoNuevo = $this->normalizarNombreYApellido($request->apellido);
 
+            $nombreNorm   = $this->normalizarNombreYApellido($request->nombre);
+            $apellidoNorm = $this->normalizarNombreYApellido($request->apellido);
+
+            if ($docente) {
+                // ── Actualizar docente existente ──────────────────────────
                 $actualizado = false;
 
-                if ($docente->nombre !== $nombreNuevo) {
-                    $docente->nombre = $nombreNuevo;
+                if ($docente->nombre !== $nombreNorm) {
+                    $docente->nombre = $nombreNorm;
                     $actualizado = true;
                 }
 
-                if ($docente->apellido !== $apellidoNuevo) {
-                    $docente->apellido = $apellidoNuevo;
+                if ($docente->apellido !== $apellidoNorm) {
+                    $docente->apellido = $apellidoNorm;
                     $actualizado = true;
                 }
 
-                // Actualizar el email si el usuario lo ha corregido
-                if ($docente->email_virtual !== $request->email) {
-                    $docente->email_virtual = $request->email;
+                // Solo generar email_virtual si el docente aún no lo tiene (#58)
+                if (empty($docente->email_virtual)) {
+                    $docente->email_virtual = $this->emailService->generarOObtenerExistente(
+                        $nombreNorm, $apellidoNorm, $dni
+                    );
                     $actualizado = true;
                 }
 
-                if($docente->de_baja) {
+                if ($docente->de_baja) {
                     $docente->de_baja = false;
                     $actualizado = true;
                 }
 
                 if ($actualizado) {
                     $docente->save();
-
-                    // Comando moosh para actualizar el docente en Moodle ( Uso de escapehellarg para que los comandos sean seguros y no puedan poner algo malicioso los usuarios )
-                    /*$command = "moosh user-update" .
-                        " --firstname " . escapeshellarg($request->nombre) .
-                        " --lastname " . escapeshellarg($request->apellido) .
-                        " " . escapeshellarg($dni);
-
-                    $this->ejecutarMoosh($command);*/
                 }
 
             } else {
-                // Si no existe, se crea
+                // ── Crear nuevo docente ───────────────────────────────────
+                // El email @fpvirtualaragon.es se genera automáticamente (#58)
+                $emailVirtual = $this->emailService->generarOObtenerExistente(
+                    $nombreNorm, $apellidoNorm, $dni
+                );
+
                 $docente = Docente::create([
-                    'dni' => $dni,
-                    'nombre' => $this->normalizarNombreYApellido($request->nombre),
-                    'apellido' => $this->normalizarNombreYApellido($request->apellido),
-                    'formacion' => $request->boolean('formacion'), // Guardamos el booleano
-                    'email_virtual' => $request->email,
+                    'dni'           => $dni,
+                    'nombre'        => $nombreNorm,
+                    'apellido'      => $apellidoNorm,
+                    'formacion'     => $request->boolean('formacion'),
+                    'email_virtual' => $emailVirtual,
                 ]);
-
-                // Comando moosh para crear nuevo usuario en Moodle ( Uso de escapehellarg para que los comandos sean seguros y no puedan poner algo malicioso los usuarios )
-                /*$command = "moosh user-create" .
-                    " --email " . escapeshellarg($request->email) .
-                    " --password " . escapeshellarg($dni) . // DNI de contraseña
-                    " --firstname " . escapeshellarg($request->nombre) .
-                    " --lastname " . escapeshellarg($request->apellido) .
-                    " " . escapeshellarg($dni);
-
-                $this->ejecutarMoosh($command); */
             }
 
-            // Asignar el docente al centro
+            // ── Asignar al centro ─────────────────────────────────────────
+            // El email personal (no @fpvirtualaragon.es) va en la tabla pivote
             CentroDocente::create([
-                'dni' => $dni,
+                'dni'       => $dni,
                 'id_centro' => $request->id_centro,
-                'email' => $request->email,
+                'email'     => $request->email,
             ]);
 
             DB::commit();
 
-            return redirect()->route('establecer_docencia.index')->with('success', 'Docente asignado correctamente.')->with('docente_dni', $docente->dni);
+            return redirect()
+                ->route('establecer_docencia.index')
+                ->with('success', 'Docente asignado correctamente.')
+                ->with('docente_dni', $docente->dni);
 
         } catch (\Exception $e) {
             DB::rollBack();
-            return redirect()->back()->withErrors(['error' => 'Hubo un error al guardar el docente.' . $e->getMessage()])->withInput();
+            return redirect()
+                ->back()
+                ->withErrors(['error' => 'Hubo un error al guardar el docente: ' . $e->getMessage()])
+                ->withInput();
         }
-
     }
 
-    //Comprueba si el dni existe para autocompletar los campos 'Nombre' y 'Apellido'
+    /**
+     * AJAX — Comprueba si el DNI existe para autocompletar el formulario.
+     * Devuelve también el email_virtual si ya está generado (#58).
+     */
     public function comprobarDocente($dni)
     {
-        $docente = Docente::where('dni', $dni)->first();
-
+        $docente  = Docente::where('dni', $dni)->first();
         $idCentro = Auth::user()->centro->id_centro;
 
         if ($docente) {
             return response()->json([
-                'existe' => true,
-                'nombre' => $docente->nombre,
-                'apellido' => $docente->apellido,
-                'email' => CentroDocente::where('dni', $dni)->where('id_centro', $idCentro)->value('email') // Obtener email del docente si existe
+                'existe'        => true,
+                'nombre'        => $docente->nombre,
+                'apellido'      => $docente->apellido,
+                'email'         => CentroDocente::where('dni', $dni)
+                                    ->where('id_centro', $idCentro)
+                                    ->value('email'),
+                'email_virtual' => $docente->email_virtual,
             ]);
         }
 
         return response()->json(['existe' => false]);
     }
 
-    //Ejecuta & Control de errores para comandos moosh
-    protected function ejecutarMoosh($command)
+    protected function ejecutarMoosh(string $command): void
     {
         exec($command, $output, $status);
         if ($status !== 0) {
-            Log::error("Fallo Moosh: " . implode("\n", $output));
+            \Log::error("Fallo Moosh: " . implode("\n", $output));
             throw new \Exception("Fallo al ejecutar comando Moosh.");
         }
     }
-
 }

--- a/app/Models/Docente.php
+++ b/app/Models/Docente.php
@@ -12,7 +12,16 @@ class Docente extends Model
     use HasFactory;
 
     // Especificamos qué campos son asignables masivamente
-    protected $fillable = ['dni', 'nombre', 'apellido', 'email_virtual', 'formacion', 'de_baja'];
+    protected $fillable = [
+        'dni', 'nombre', 'apellido', 'email_virtual', 'formacion',
+        'de_baja', 'is_procesado', 'fecha_procesado',
+    ];
+
+    protected $casts = [
+        'de_baja'        => 'boolean',
+        'is_procesado'   => 'boolean',
+        'fecha_procesado' => 'datetime',
+    ];
 
 
 public function centros()

--- a/app/Services/GeneradorEmailVirtualService.php
+++ b/app/Services/GeneradorEmailVirtualService.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Docente;
+
+/**
+ * GeneradorEmailVirtualService
+ *
+ * Genera automáticamente el correo @fpvirtualaragon.es de un docente
+ * siguiendo el algoritmo acordado:
+ *
+ *   local = iniciales(nombre) + primer_apellido + inicial(segundo_apellido)
+ *   email = strtolower(transliterate(local)) + "@fpvirtualaragon.es"
+ *
+ * Ejemplos:
+ *   "Dario Axel"          + "Ureña Garcia"  → daurenag@fpvirtualaragon.es
+ *   "María Del Carmen Mónica" + "Royo Lupón" → mdcmroyol@fpvirtualaragon.es
+ *
+ * Colisiones: si el email ya existe en BD se añade sufijo numérico (…2, …3, …)
+ */
+class GeneradorEmailVirtualService
+{
+    public const DOMINIO = 'fpvirtualaragon.es';
+
+    /**
+     * Devuelve el email virtual del docente:
+     * - Si ya tiene email_virtual en BD → lo devuelve sin modificar.
+     * - Si es nuevo → genera y resuelve colisiones.
+     *
+     * @param  string      $nombre    Nombre(s) del docente (normalizado, con mayúsculas)
+     * @param  string      $apellido  Apellidos separados por espacio
+     * @param  string|null $dni       DNI del docente (para buscar si ya existe)
+     * @return string                 Email completo @fpvirtualaragon.es
+     */
+    public function generarOObtenerExistente(string $nombre, string $apellido, ?string $dni = null): string
+    {
+        // Si el docente ya existe en BD con email_virtual, respetarlo
+        if ($dni) {
+            $emailExistente = Docente::where('dni', strtoupper($dni))->value('email_virtual');
+            if (!empty($emailExistente)) {
+                return $emailExistente;
+            }
+        }
+
+        $base = $this->construirLocalPart($nombre, $apellido);
+
+        return $this->resolverColision($base);
+    }
+
+    /**
+     * Genera el email sin resolver colisiones — útil para preview en formulario.
+     */
+    public function previsualizarEmail(string $nombre, string $apellido): string
+    {
+        return $this->construirLocalPart($nombre, $apellido) . '@' . self::DOMINIO;
+    }
+
+    // ── Algoritmo ────────────────────────────────────────────────────────────
+
+    /**
+     * Construye la parte local del email:
+     *   iniciales(nombre) + primer_apellido + inicial(segundo_apellido)
+     *
+     * Todo en minúsculas y transliterado (sin acentos, sin ñ, solo [a-z0-9]).
+     */
+    public function construirLocalPart(string $nombre, string $apellido): string
+    {
+        // 1. Iniciales de todos los nombres
+        $palabrasNombre = preg_split('/\s+/', trim($nombre));
+        $iniciales = implode('', array_map(
+            fn(string $p) => mb_strtoupper(mb_substr($p, 0, 1, 'UTF-8'), 'UTF-8'),
+            array_filter($palabrasNombre, fn($p) => $p !== '')
+        ));
+
+        // 2. Primer apellido completo + inicial del segundo (si lo hay)
+        $palabrasApellido = preg_split('/\s+/', trim($apellido));
+        $primerApellido   = $palabrasApellido[0] ?? '';
+        $segundoApellido  = $palabrasApellido[1] ?? null;
+        $inicialSegundo   = $segundoApellido
+            ? mb_strtoupper(mb_substr($segundoApellido, 0, 1, 'UTF-8'), 'UTF-8')
+            : '';
+
+        // 3. Concatenar y normalizar
+        $localRaw = $iniciales . $primerApellido . $inicialSegundo;
+
+        return $this->normalizar($localRaw);
+    }
+
+    /**
+     * Convierte a minúsculas, transliterada a ASCII y elimina chars no válidos.
+     */
+    public function normalizar(string $str): string
+    {
+        $str = mb_strtolower($str, 'UTF-8');
+
+        // Mapa de transliteración (vocales acentuadas, ñ, ç, etc.)
+        $mapa = [
+            'á' => 'a', 'à' => 'a', 'â' => 'a', 'ä' => 'a', 'ã' => 'a', 'å' => 'a',
+            'é' => 'e', 'è' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'í' => 'i', 'ì' => 'i', 'î' => 'i', 'ï' => 'i',
+            'ó' => 'o', 'ò' => 'o', 'ô' => 'o', 'ö' => 'o', 'õ' => 'o', 'ø' => 'o',
+            'ú' => 'u', 'ù' => 'u', 'û' => 'u', 'ü' => 'u',
+            'ñ' => 'n', 'ç' => 'c', 'ý' => 'y', 'ÿ' => 'y',
+            'ß' => 'ss',
+        ];
+
+        $str = strtr($str, $mapa);
+
+        // Eliminar cualquier carácter no alfanumérico
+        return preg_replace('/[^a-z0-9]/', '', $str);
+    }
+
+    // ── Colisiones ───────────────────────────────────────────────────────────
+
+    /**
+     * Comprueba si el email base ya está en uso y añade sufijo numérico si hace falta.
+     *
+     * Ejemplos:
+     *   daurenag  → daurenag@fpvirtualaragon.es  (libre → lo usa)
+     *   daurenag  → daurenag2@fpvirtualaragon.es (ocupado → prueba 2, 3, …)
+     */
+    private function resolverColision(string $base): string
+    {
+        $email = $base . '@' . self::DOMINIO;
+
+        if (!Docente::where('email_virtual', $email)->exists()) {
+            return $email;
+        }
+
+        $sufijo = 2;
+        do {
+            $email = $base . $sufijo . '@' . self::DOMINIO;
+            $sufijo++;
+        } while (Docente::where('email_virtual', $email)->exists() && $sufijo < 100);
+
+        return $email;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -14,5 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->render(function (AuthenticationException $e, Request $request) {
+            if ($request->is('admin') || $request->is('admin/*')) {
+                return redirect()->guest(route('admin.login'));
+            }
+        });
     })->create();

--- a/database/migrations/2026_05_22_075715_add_procesado_to_docentes_table.php
+++ b/database/migrations/2026_05_22_075715_add_procesado_to_docentes_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('docentes', function (Blueprint $table) {
+            $table->boolean('is_procesado')->default(false)->after('de_baja');
+            $table->timestamp('fecha_procesado')->nullable()->after('is_procesado');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('docentes', function (Blueprint $table) {
+            $table->dropColumn(['is_procesado', 'fecha_procesado']);
+        });
+    }
+};

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -1,0 +1,330 @@
+@extends('layouts.app-admin')
+
+@section('content')
+
+@push('styles')
+<style>
+    .ap-panel      { background:#fff; border-radius:12px; box-shadow:0 2px 12px rgba(0,0,0,.08); padding:2rem; margin:2rem auto; max-width:1100px; }
+    .ap-title      { font-size:1.4rem; font-weight:700; color:#1e3a5f; margin-bottom:.25rem; }
+    .ap-subtitle   { font-size:.9rem; color:#64748b; margin-bottom:1.5rem; }
+    .ap-table      { width:100%; border-collapse:collapse; font-size:.9rem; }
+    .ap-table th   { background:#f1f5f9; color:#475569; text-align:left; padding:.6rem .8rem; border-bottom:2px solid #e2e8f0; }
+    .ap-table td   { padding:.55rem .8rem; border-bottom:1px solid #f1f5f9; vertical-align:middle; }
+    .ap-table tr:hover td { background:#f8fafc; }
+    .btn-primary   { background:#4f46e5; color:#fff; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
+    .btn-primary:hover   { background:#4338ca; }
+    .btn-secondary { background:#e2e8f0; color:#334155; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
+    .btn-secondary:hover { background:#cbd5e1; }
+    .btn-success   { background:#16a34a; color:#fff; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
+    .btn-success:hover   { background:#15803d; }
+    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:40; display:flex; align-items:center; justify-content:center; }
+    .modal-box     { background:#fff; border-radius:12px; padding:2rem; max-width:560px; width:90%; box-shadow:0 8px 32px rgba(0,0,0,.18); }
+    .modal-title   { font-size:1.1rem; font-weight:700; color:#1e3a5f; margin-bottom:1rem; }
+    .csv-preview   { background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px; padding:.75rem 1rem; font-family:monospace; font-size:.8rem; word-break:break-all; color:#334155; margin-bottom:.5rem; }
+    .divider       { border:none; border-top:1px solid #e2e8f0; margin:1.25rem 0; }
+    .tick-ok       { color:#16a34a; font-size:.9rem; font-weight:600; }
+    .tick-no       { color:#dc2626; font-size:.9rem; font-weight:600; }
+</style>
+@endpush
+
+<div class="ap-panel" x-data="altaPlataforma()">
+
+    <h3 class="ap-title"><i class="fas fa-cloud-upload-alt mr-2 text-indigo-600"></i>Alta en Plataforma</h3>
+    <p class="ap-subtitle">Selecciona los docentes para generar los CSV de Google Workspace y Moodle.</p>
+
+    {{-- Filtros --}}
+    <form method="GET" action="{{ route('admin.alta-plataforma') }}" class="flex flex-wrap gap-3 mb-5">
+        <input type="text" name="buscar" value="{{ request('buscar') }}"
+               placeholder="Buscar por nombre, apellido o DNI..."
+               class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300 w-64">
+        <select name="estado" class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300">
+            <option value="">— Todos los estados —</option>
+            <option value="pendiente" @selected(request('estado') === 'pendiente')>Pendiente de alta</option>
+            <option value="procesado" @selected(request('estado') === 'procesado')>Procesado</option>
+        </select>
+        <button type="submit" class="btn-secondary"><i class="fas fa-search mr-1"></i> Filtrar</button>
+        <a href="{{ route('admin.alta-plataforma') }}" class="btn-secondary"><i class="fas fa-times mr-1"></i> Limpiar</a>
+    </form>
+
+    {{-- Tabla --}}
+    <div class="overflow-x-auto">
+        <table class="ap-table">
+            <thead>
+                <tr>
+                    <th><input type="checkbox" @change="toggleAll($event)" x-ref="checkAll"></th>
+                    <th>DNI</th>
+                    <th>Nombre</th>
+                    <th>Apellidos</th>
+                    <th>Email @fpvirtualaragon.es</th>
+                    <th>Estado exportación</th>
+                    <th>Fecha exportación</th>
+                    <th>Ver CSV</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($docentes as $docente)
+                <tr>
+                    <td>
+                        <input type="checkbox"
+                               value="{{ $docente->id }}"
+                               x-model="selected"
+                               @change="syncCheckAll">
+                    </td>
+                    <td class="font-mono text-xs">{{ $docente->dni }}</td>
+                    <td>{{ $docente->nombre }}</td>
+                    <td>{{ $docente->apellido }}</td>
+                    <td class="text-indigo-700 font-medium text-xs">{{ $docente->email_virtual }}</td>
+
+                    {{-- Estado: reactivo vía Alpine --}}
+                    <td>
+                        <span x-show="getEstado({{ $docente->id }})" class="tick-ok">
+                            <i class="fas fa-check-circle"></i> Exportado
+                        </span>
+                        <span x-show="!getEstado({{ $docente->id }})" class="tick-no">
+                            <i class="fas fa-times-circle"></i> Pendiente
+                        </span>
+                    </td>
+
+                    {{-- Fecha: reactiva vía Alpine --}}
+                    <td class="text-xs text-gray-500"
+                        x-text="getFecha({{ $docente->id }})">
+                    </td>
+
+                    <td>
+                        <button class="text-indigo-600 hover:text-indigo-800 text-xs font-semibold"
+                                @click="verDetalle({{ $docente->id }})">
+                            <i class="fas fa-eye mr-1"></i>Ver CSV
+                        </button>
+                    </td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="8" class="text-center text-gray-400 py-8">No hay docentes que coincidan con los filtros.</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    {{-- Paginación --}}
+    <div class="mt-4">
+        {{ $docentes->links() }}
+    </div>
+
+    {{-- Botón generar CSVs --}}
+    <div class="mt-6 flex items-center gap-4">
+        <span class="text-sm text-gray-500" x-text="selected.length + ' docente(s) seleccionado(s)'"></span>
+        <button class="btn-primary"
+                :disabled="selected.length === 0"
+                :class="{ 'opacity-50 cursor-not-allowed': selected.length === 0 }"
+                @click="abrirExport()">
+            <i class="fas fa-file-csv mr-2"></i>Generar CSVs
+        </button>
+    </div>
+
+    {{-- Modal: previsualización CSV de un docente --}}
+    <div class="modal-overlay" x-show="showPreview" x-cloak @click.self="showPreview = false">
+        <div class="modal-box">
+            <h4 class="modal-title"><i class="fas fa-eye mr-2 text-indigo-500"></i>Previsualización CSV</h4>
+            <template x-if="previewDocente">
+                <div>
+                    <p class="text-sm text-gray-600 mb-3">
+                        <strong x-text="previewDocente.nombre + ' ' + previewDocente.apellido"></strong>
+                        &nbsp;|&nbsp; <span class="font-mono text-xs" x-text="previewDocente.dni"></span>
+                    </p>
+                    <p class="text-xs font-semibold text-gray-500 mb-1">Google Workspace CSV:</p>
+                    <div class="csv-preview" x-text="csvLineGoogle(previewDocente)"></div>
+                    <p class="text-xs font-semibold text-gray-500 mb-1 mt-3">Moodle CSV:</p>
+                    <div class="csv-preview" x-text="csvLineMoodle(previewDocente)"></div>
+                </div>
+            </template>
+            <div class="flex justify-end mt-4">
+                <button class="btn-secondary" @click="showPreview = false">Cerrar</button>
+            </div>
+        </div>
+    </div>
+
+    {{-- Modal: exportar y actualizar estado --}}
+    <div class="modal-overlay" x-show="showExport" x-cloak>
+        <div class="modal-box" style="max-width:640px;">
+            <h4 class="modal-title">
+                <i class="fas fa-file-download mr-2 text-indigo-500"></i>Exportar CSVs
+            </h4>
+
+            <p class="text-sm text-gray-600 mb-4">
+                Descarga los ficheros para
+                <strong x-text="selectedDocentes().length"></strong>
+                docente(s) seleccionado(s) y, cuando estés listo/a, cierra actualizando el estado.
+            </p>
+
+            {{-- Botones de descarga --}}
+            <div class="flex flex-wrap gap-3 mb-2">
+                <button class="btn-primary" @click="downloadCSV('google')">
+                    <i class="fab fa-google mr-1"></i>Descargar CSV Google Workspace
+                </button>
+                <button class="btn-primary" @click="downloadCSV('moodle')">
+                    <i class="fas fa-graduation-cap mr-1"></i>Descargar CSV Moodle
+                </button>
+            </div>
+
+            <hr class="divider">
+
+            {{-- Botones de cierre --}}
+            <div class="flex flex-wrap justify-between items-center gap-3">
+                <button class="btn-secondary" @click="cerrarSinActualizar()">
+                    <i class="fas fa-times mr-1"></i>Cerrar sin actualizar estado
+                </button>
+                <button class="btn-success"
+                        :disabled="procesando"
+                        :class="{ 'opacity-60 cursor-not-allowed': procesando }"
+                        @click="cerrarActualizando()">
+                    <span x-show="!procesando">
+                        <i class="fas fa-check-circle mr-1"></i>Cerrar y actualizar estado
+                    </span>
+                    <span x-show="procesando">
+                        <i class="fas fa-spinner fa-spin mr-1"></i>Actualizando…
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script>
+document.addEventListener('alpine:init', () => {
+    Alpine.data('altaPlataforma', () => ({
+        selected: [],
+        showPreview: false,
+        showExport: false,
+        previewDocente: null,
+        procesando: false,
+        docenteMap: @json($docentesJson),
+
+        // ── Helpers de estado reactivo ─────────────────────────────────
+        getEstado(id) {
+            return this.docenteMap.find(d => d.id === id)?.is_procesado ?? false;
+        },
+
+        getFecha(id) {
+            return this.docenteMap.find(d => d.id === id)?.fecha_procesado ?? '—';
+        },
+
+        // ── Selección ──────────────────────────────────────────────────
+        toggleAll(event) {
+            if (event.target.checked) {
+                this.selected = this.docenteMap.map(d => d.id);
+            } else {
+                this.selected = [];
+            }
+        },
+
+        syncCheckAll() {
+            const allIds = this.docenteMap.map(d => d.id);
+            this.$refs.checkAll.checked = allIds.length > 0 && allIds.every(id => this.selected.includes(id));
+            this.$refs.checkAll.indeterminate = this.selected.length > 0 && !this.$refs.checkAll.checked;
+        },
+
+        selectedDocentes() {
+            return this.docenteMap.filter(d => this.selected.includes(d.id));
+        },
+
+        // ── Detalle / preview ──────────────────────────────────────────
+        verDetalle(id) {
+            this.previewDocente = this.docenteMap.find(d => d.id === id) ?? null;
+            this.showPreview = true;
+        },
+
+        abrirExport() {
+            if (this.selected.length === 0) return;
+            this.showExport = true;
+        },
+
+        // ── Generación CSV ─────────────────────────────────────────────
+        csvLineGoogle(d) {
+            const nombre = (d.nombre + ' ' + d.apellido).replace(/"/g, '""');
+            return `"${nombre}","${d.email_virtual}",,`;
+        },
+
+        csvLineMoodle(d) {
+            const user    = 'prof' + d.dni;
+            const nombre  = (d.nombre  || '').replace(/"/g, '""');
+            const apellido = (d.apellido || '').replace(/"/g, '""');
+            return `"${user}","${nombre}","${apellido}","${d.email_virtual}"`;
+        },
+
+        downloadCSV(tipo) {
+            const docs = this.selectedDocentes();
+            let lines  = [];
+
+            if (tipo === 'google') {
+                lines.push('Nombre,Correo,Contraseña,Unidad organizativa');
+                docs.forEach(d => lines.push(this.csvLineGoogle(d)));
+            } else {
+                lines.push('username,firstname,lastname,email');
+                docs.forEach(d => lines.push(this.csvLineMoodle(d)));
+            }
+
+            const bom  = '﻿';
+            const blob = new Blob([bom + lines.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
+            const url  = URL.createObjectURL(blob);
+            const a    = document.createElement('a');
+            a.href     = url;
+            a.download = tipo === 'google' ? 'alta_google_workspace.csv' : 'alta_moodle.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+        },
+
+        // ── Botones de cierre del modal ────────────────────────────────
+        cerrarSinActualizar() {
+            this.showExport = false;
+        },
+
+        cerrarActualizando() {
+            if (this.procesando) return;
+            this.procesando = true;
+
+            const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+            const idsAmarcar = [...this.selected];
+
+            fetch('{{ route("admin.alta-plataforma.procesar") }}', {
+                method:  'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': token,
+                    'Accept':       'application/json',
+                },
+                body: JSON.stringify({ ids: idsAmarcar }),
+            })
+            .then(r => r.ok ? r.json() : Promise.reject(r))
+            .then(() => {
+                // Actualizar estado en el docenteMap local (sin recargar página)
+                const ahora = new Date().toLocaleString('es-ES', {
+                    day: '2-digit', month: '2-digit', year: 'numeric',
+                    hour: '2-digit', minute: '2-digit',
+                });
+                idsAmarcar.forEach(id => {
+                    const d = this.docenteMap.find(d => d.id === id);
+                    if (d) {
+                        d.is_procesado   = true;
+                        d.fecha_procesado = ahora;
+                    }
+                });
+
+                this.showExport = false;
+                this.selected   = [];
+                if (this.$refs.checkAll) this.$refs.checkAll.checked = false;
+            })
+            .catch(() => {
+                alert('Error al actualizar el estado. Inténtalo de nuevo.');
+            })
+            .finally(() => {
+                this.procesando = false;
+            });
+        },
+    }));
+});
+</script>
+@endpush
+
+@endsection

--- a/resources/views/alta_docente.blade.php
+++ b/resources/views/alta_docente.blade.php
@@ -89,6 +89,27 @@
                         </div>
                     </div>
 
+                    <!-- Email @fpvirtualaragon.es generado automáticamente (#58) -->
+                    <div class="alta-form-group">
+                        <label class="alta-label">
+                            <i class="fas fa-at mr-1"></i> Correo @fpvirtualaragon.es (generado automáticamente):
+                        </label>
+                        <div class="input-wrapper" style="position:relative;">
+                            <input type="text" id="email_virtual_preview"
+                                   class="alta-input"
+                                   readonly
+                                   placeholder="Se generará al introducir nombre y apellidos"
+                                   style="background:#f3f4f6; color:#4f46e5; font-weight:500;">
+                            <span id="email-spinner" style="display:none; position:absolute; right:10px; top:50%; transform:translateY(-50%);">
+                                <i class="fas fa-spinner fa-spin text-indigo-400"></i>
+                            </span>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">
+                            <i class="fas fa-info-circle"></i>
+                            Este correo se asigna automáticamente. No es editable.
+                        </p>
+                    </div>
+
                     <input type="hidden" name="id_centro" value="{{ $centro->id_centro }}">
 
                     <div class="alta-form-actions">
@@ -113,6 +134,35 @@
             const emailInput = document.getElementById('email');
             const toggleNombre = document.getElementById('toggle-nombre');
             const toggleApellido = document.getElementById('toggle-apellido');
+            const emailVirtualPreview = document.getElementById('email_virtual_preview');
+            const emailSpinner = document.getElementById('email-spinner');
+
+            let previewTimer = null;
+
+            function actualizarPreviewEmail() {
+                const nombre = nombreInput.value.trim();
+                const apellido = apellidoInput.value.trim();
+
+                if (!nombre || !apellido) {
+                    emailVirtualPreview.value = '';
+                    return;
+                }
+
+                clearTimeout(previewTimer);
+                previewTimer = setTimeout(() => {
+                    emailSpinner.style.display = 'inline';
+                    fetch(`/alta-docente/preview-email?nombre=${encodeURIComponent(nombre)}&apellido=${encodeURIComponent(apellido)}`)
+                        .then(r => r.ok ? r.json() : Promise.reject())
+                        .then(data => {
+                            emailVirtualPreview.value = data.email ?? '';
+                        })
+                        .catch(() => { emailVirtualPreview.value = ''; })
+                        .finally(() => { emailSpinner.style.display = 'none'; });
+                }, 400);
+            }
+
+            nombreInput.addEventListener('input', actualizarPreviewEmail);
+            apellidoInput.addEventListener('input', actualizarPreviewEmail);
 
             function setLockIcon(input, icon) {
                 if (input.readOnly) {
@@ -179,6 +229,13 @@
                             // Rellenar el email con el valor actual de BD (editable por el usuario)
                             if (data.email) {
                                 emailInput.value = data.email;
+                            }
+
+                            // Mostrar email_virtual si ya está generado
+                            if (data.email_virtual) {
+                                emailVirtualPreview.value = data.email_virtual;
+                            } else {
+                                actualizarPreviewEmail();
                             }
 
                             // Mostrar notificación con aviso de revisión de email

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -26,6 +26,11 @@
                         {{ __('Ver Centros') }}
                     </x-nav-link>
                 </div>
+                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                    <x-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
+                        {{ __('Alta Plataforma') }}
+                    </x-nav-link>
+                </div>
             </div>
 
             <!-- Settings Dropdown -->
@@ -91,6 +96,11 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('admin.centros')" :active="request()->routeIs('admin.centros')">
                 {{ __('Ver Centros') }}
+            </x-responsive-nav-link>
+        </div>
+        <div class="pt-2 pb-3 space-y-1">
+            <x-responsive-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
+                {{ __('Alta Plataforma') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -19,7 +19,9 @@
 
 
 
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @if(app()->environment() !== 'testing')
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @endif
     <link rel="stylesheet" href="{{ asset('css/dashboard.css') }}" />
     @stack('styles')
 </head>
@@ -39,5 +41,6 @@
              @yield('content')
         </main>
     </div>
+    @stack('scripts')
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\BajaDocenteController;
 use App\Http\Controllers\Admin\Auth\LoginController as AdminLoginController;
 use App\Http\Controllers\Admin\DocenteController;
 use App\Http\Controllers\Admin\CentroController;
+use App\Http\Controllers\Admin\AltaPlataformaController;
 
 Route::redirect('/', '/login');
 
@@ -33,6 +34,8 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/alta-docente', [AltaDocenteController::class, 'store'])
         ->name('alta_docente.store');
     Route::get('/comprobar-docente/{dni}', [AltaDocenteController::class, 'comprobarDocente']);
+    Route::get('/alta-docente/preview-email', [AltaDocenteController::class, 'previewEmail'])
+        ->name('alta_docente.preview_email');
 
     // Cambiamos a POST para que sea más fácil de usar en botones simples
     Route::post('/docentes/baja/{dni}', [BajaDocenteController::class, 'destroy'])->name('docente.baja');
@@ -114,7 +117,11 @@ Route::middleware('web')->prefix('admin')->name('admin.')->group(function () {
         Route::get('centros/exportar-csv', [CentroController::class, 'exportCentrosCSV'])
             ->name('centros.export.csv');
 
-
+        Route::get('alta-plataforma', [AltaPlataformaController::class, 'index'])
+            ->name('alta-plataforma');
+        Route::get('alta-plataforma/{id}/preview', [AltaPlataformaController::class, 'preview']);
+        Route::post('alta-plataforma/procesar', [AltaPlataformaController::class, 'procesarAltas'])
+            ->name('alta-plataforma.procesar');
 
     });
 });

--- a/tests/Feature/AltaPlataformaTest.php
+++ b/tests/Feature/AltaPlataformaTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * Suite de tests — Issue #60: Vista para altas individuales/masivas del profesorado
+ *
+ * Cubre:
+ *   A) Acceso y autenticación
+ *   B) procesarAltas (POST /admin/alta-plataforma/procesar)
+ *   C) Endpoint preview (GET /admin/alta-plataforma/{id}/preview)
+ *   D) Filtros (estado, búsqueda)
+ *
+ * Ejecución:
+ *   ./vendor/bin/pest tests/Feature/AltaPlataformaTest.php --no-coverage
+ */
+
+use App\Models\Admin;
+use App\Models\Docente;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+function adminUser(): Admin
+{
+    return Admin::forceCreate([
+        'user'     => 'admin_test',
+        'email'    => 'admin@test.com',
+        'password' => bcrypt('secret'),
+    ]);
+}
+
+function docenteConEmail(array $extra = []): Docente
+{
+    static $seq = 0;
+    $seq++;
+    return Docente::forceCreate(array_merge([
+        'nombre'        => 'Docente',
+        'apellido'      => 'Apellido',
+        'dni'           => str_pad($seq, 8, '0', STR_PAD_LEFT) . 'X',
+        'email_virtual' => "docente{$seq}@fpvirtualaragon.es",
+        'de_baja'       => false,
+        'is_procesado'  => false,
+    ], $extra));
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE A — Acceso y autenticación
+// ════════════════════════════════════════════════════════════════════════════
+
+test('A1 · un invitado es redirigido a admin/login al acceder a alta-plataforma', function () {
+    $response = $this->get('/admin/alta-plataforma');
+    $response->assertRedirect(route('admin.login'));
+});
+
+test('A2 · un usuario normal (guard web) es redirigido a admin/login', function () {
+    $centro  = \App\Models\Centro::forceCreate(['id_centro' => 'CA01', 'nombre' => 'Centro A']);
+    $usuario = \App\Models\Usuario::factory()->create(['id_centro' => 'CA01']);
+
+    $response = $this->actingAs($usuario)->get('/admin/alta-plataforma');
+    $response->assertRedirect(route('admin.login'));
+});
+
+test('A3 · un admin autenticado puede acceder a la página', function () {
+    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
+    $response->assertStatus(200);
+});
+
+test('A4 · la página contiene el título esperado', function () {
+    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
+    $response->assertSee('Alta en Plataforma');
+});
+
+test('A5 · la página muestra los docentes activos con email_virtual', function () {
+    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Herrera']);
+    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Montes']);
+
+    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
+    $response->assertSee('Guillermo');
+    $response->assertSee('Valentina');
+});
+
+test('A6 · la página NO muestra docentes de baja', function () {
+    docenteConEmail(['nombre' => 'BajaDocente', 'apellido' => 'Oculto', 'de_baja' => true]);
+
+    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
+    $response->assertDontSee('BajaDocente');
+});
+
+test('A7 · la página NO muestra docentes sin email_virtual', function () {
+    Docente::forceCreate([
+        'nombre'        => 'SinEmail',
+        'apellido'      => 'Virtual',
+        'dni'           => '99999901S',
+        'email_virtual' => '',
+        'de_baja'       => false,
+    ]);
+
+    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
+    $response->assertDontSee('SinEmail');
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE B — procesarAltas
+// ════════════════════════════════════════════════════════════════════════════
+
+test('B1 · procesar un docente lo marca como is_procesado=true', function () {
+    $docente = docenteConEmail();
+
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]])
+         ->assertStatus(200)
+         ->assertJson(['ok' => true]);
+
+    expect($docente->fresh()->is_procesado)->toBeTrue();
+});
+
+test('B2 · procesar un docente guarda la fecha_procesado', function () {
+    $docente = docenteConEmail();
+
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]]);
+
+    expect($docente->fresh()->fecha_procesado)->not->toBeNull();
+});
+
+test('B3 · procesar varios docentes a la vez actualiza todos', function () {
+    $d1 = docenteConEmail();
+    $d2 = docenteConEmail();
+
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$d1->id, $d2->id]])
+         ->assertJson(['ok' => true, 'procesados' => 2]);
+
+    expect($d1->fresh()->is_procesado)->toBeTrue();
+    expect($d2->fresh()->is_procesado)->toBeTrue();
+});
+
+test('B4 · procesar sin ids devuelve error de validación', function () {
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', [])
+         ->assertStatus(422);
+});
+
+test('B5 · procesar con ids vacíos devuelve error de validación', function () {
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => []])
+         ->assertStatus(422);
+});
+
+test('B6 · un docente de baja no se marca como procesado aunque esté en los ids', function () {
+    $docente = docenteConEmail(['de_baja' => true, 'is_procesado' => false]);
+
+    $this->actingAs(adminUser(), 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]]);
+
+    expect($docente->fresh()->is_procesado)->toBeFalse();
+});
+
+test('B7 · un invitado no puede llamar a procesarAltas', function () {
+    $docente = docenteConEmail();
+
+    $this->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]])
+         ->assertStatus(302); // redirige al login
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE C — Endpoint preview
+// ════════════════════════════════════════════════════════════════════════════
+
+test('C1 · el endpoint preview devuelve el dni del docente', function () {
+    $docente = docenteConEmail(['dni' => '12345678C']);
+
+    $this->actingAs(adminUser(), 'admin')
+         ->getJson("/admin/alta-plataforma/{$docente->id}/preview")
+         ->assertStatus(200)
+         ->assertJsonPath('dni', '12345678C');
+});
+
+test('C2 · el endpoint preview devuelve el email_virtual', function () {
+    $docente = docenteConEmail(['email_virtual' => 'preview@fpvirtualaragon.es']);
+
+    $this->actingAs(adminUser(), 'admin')
+         ->getJson("/admin/alta-plataforma/{$docente->id}/preview")
+         ->assertStatus(200)
+         ->assertJsonPath('email_virtual', 'preview@fpvirtualaragon.es');
+});
+
+test('C3 · el endpoint preview incluye la línea google_csv', function () {
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $response->assertStatus(200);
+    expect($response->json('google_csv'))->toBeString()->not->toBeEmpty();
+});
+
+test('C4 · el endpoint preview incluye la línea moodle_csv', function () {
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $response->assertStatus(200);
+    expect($response->json('moodle_csv'))->toBeString()->not->toBeEmpty();
+});
+
+test('C5 · la línea moodle_csv empieza con "prof" seguido del DNI', function () {
+    $docente = docenteConEmail(['dni' => '87654321M']);
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    expect($response->json('moodle_csv'))->toStartWith('"prof87654321M"');
+});
+
+test('C6 · el endpoint preview devuelve 404 para un id inexistente', function () {
+    $this->actingAs(adminUser(), 'admin')
+         ->getJson('/admin/alta-plataforma/9999/preview')
+         ->assertStatus(404);
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE D — Filtros
+// ════════════════════════════════════════════════════════════════════════════
+
+test('D1 · el filtro estado=pendiente solo muestra docentes no procesados', function () {
+    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Sin Procesar', 'is_procesado' => false]);
+    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Ya Procesada', 'is_procesado' => true]);
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->get('/admin/alta-plataforma?estado=pendiente');
+
+    $response->assertSee('Guillermo');
+    $response->assertDontSee('Valentina');
+});
+
+test('D2 · el filtro estado=procesado solo muestra docentes procesados', function () {
+    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Sin Procesar', 'is_procesado' => false]);
+    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Ya Procesada', 'is_procesado' => true]);
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->get('/admin/alta-plataforma?estado=procesado');
+
+    $response->assertSee('Valentina');
+    $response->assertDontSee('Guillermo');
+});
+
+test('D3 · la búsqueda por nombre filtra correctamente', function () {
+    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Herrera']);
+    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Montes']);
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->get('/admin/alta-plataforma?buscar=Guillermo');
+
+    $response->assertSee('Guillermo');
+    $response->assertDontSee('Valentina');
+});
+
+test('D4 · la búsqueda por DNI filtra correctamente', function () {
+    docenteConEmail(['dni' => 'A1111111Z', 'nombre' => 'Guillermo', 'apellido' => 'Herrera']);
+    docenteConEmail(['dni' => 'B2222222Z', 'nombre' => 'Valentina', 'apellido' => 'Montes']);
+
+    $response = $this->actingAs(adminUser(), 'admin')
+         ->get('/admin/alta-plataforma?buscar=A1111111Z');
+
+    $response->assertSee('Guillermo');
+    $response->assertDontSee('Valentina');
+});

--- a/tests/Feature/GeneradorEmailVirtualTest.php
+++ b/tests/Feature/GeneradorEmailVirtualTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * Suite de tests — Issue #58: Generación de correo @fpvirtualaragon.es
+ *
+ * Cubre:
+ *   A) Algoritmo del servicio GeneradorEmailVirtualService
+ *   B) Integración con alta de docentes (AltaDocenteController@store)
+ *   C) Endpoint AJAX previewEmail
+ *   D) Colisiones y casos límite
+ *
+ * Ejecución:
+ *   ./vendor/bin/pest tests/Feature/GeneradorEmailVirtualTest.php --no-coverage
+ */
+
+use App\Models\Centro;
+use App\Models\Docente;
+use App\Models\Usuario;
+use App\Services\GeneradorEmailVirtualService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+function servicio(): GeneradorEmailVirtualService
+{
+    return new GeneradorEmailVirtualService();
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE A — Algoritmo del servicio
+// ════════════════════════════════════════════════════════════════════════════
+
+test('A1 · genera el email correcto para el ejemplo de la tabla (Dario Axel Ureña Garcia)', function () {
+    $email = servicio()->previsualizarEmail('Dario Axel', 'Ureña Garcia');
+    expect($email)->toBe('daurenag@fpvirtualaragon.es');
+});
+
+test('A2 · genera el email correcto para el ejemplo de la tabla (María Del Carmen Mónica Royo Lupón)', function () {
+    $email = servicio()->previsualizarEmail('María Del Carmen Mónica', 'Royo Lupón');
+    expect($email)->toBe('mdcmroyol@fpvirtualaragon.es');
+});
+
+test('A3 · docente con un solo nombre y dos apellidos', function () {
+    $email = servicio()->previsualizarEmail('Ana', 'García López');
+    expect($email)->toBe('agarcial@fpvirtualaragon.es');
+});
+
+test('A4 · docente con un solo apellido (sin segundo apellido)', function () {
+    $email = servicio()->previsualizarEmail('Juan', 'García');
+    expect($email)->toBe('jgarcia@fpvirtualaragon.es');
+});
+
+test('A5 · los acentos se eliminan en la parte local del email', function () {
+    $email = servicio()->previsualizarEmail('Óscar', 'Pérez Ávila');
+    expect($email)->toBe('opereza@fpvirtualaragon.es');
+});
+
+test('A6 · la ñ se convierte en n', function () {
+    $email = servicio()->previsualizarEmail('Pedro', 'Muñoz Niño');
+    expect($email)->toBe('pmunozn@fpvirtualaragon.es');
+});
+
+test('A7 · nombres con múltiples palabras generan todas sus iniciales', function () {
+    $email = servicio()->previsualizarEmail('José Luis María', 'Sánchez Torres');
+    expect($email)->toBe('jlmsanchezt@fpvirtualaragon.es');
+});
+
+test('A8 · el email generado usa siempre el dominio fpvirtualaragon.es', function () {
+    $email = servicio()->previsualizarEmail('Test', 'Apellido');
+    expect($email)->toEndWith('@fpvirtualaragon.es');
+});
+
+test('A9 · el email generado está completamente en minúsculas', function () {
+    $email = servicio()->previsualizarEmail('JUAN CARLOS', 'FERNÁNDEZ RUIZ');
+    expect($email)->toBe(strtolower($email));
+});
+
+test('A10 · no contiene caracteres no ASCII en la parte local', function () {
+    $email = servicio()->previsualizarEmail('Ángel', 'Martínez Cañón');
+    $localPart = explode('@', $email)[0];
+    expect($localPart)->toMatch('/^[a-z0-9]+$/');
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE B — Integración con alta de docentes
+// ════════════════════════════════════════════════════════════════════════════
+
+test('B1 · al dar de alta un docente nuevo se genera automáticamente el email_virtual', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C001', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C001']);
+
+    $this->actingAs($usuario)->post('/alta-docente', [
+        'nombre'    => 'Laura',
+        'apellido'  => 'Sánchez Pérez',
+        'dni'       => '12345678L',
+        'email'     => 'laura@micentro.com',
+        'id_centro' => 'C001',
+    ]);
+
+    $docente = Docente::where('dni', '12345678L')->first();
+    expect($docente)->not->toBeNull();
+    expect($docente->email_virtual)->toBe('lsanchezp@fpvirtualaragon.es');
+});
+
+test('B2 · el email_virtual termina en @fpvirtualaragon.es al dar de alta', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C002', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C002']);
+
+    $this->actingAs($usuario)->post('/alta-docente', [
+        'nombre'    => 'Carlos',
+        'apellido'  => 'Ruiz',
+        'dni'       => '87654321C',
+        'email'     => 'carlos@micentro.com',
+        'id_centro' => 'C002',
+    ]);
+
+    $docente = Docente::where('dni', '87654321C')->first();
+    expect($docente->email_virtual)->toEndWith('@fpvirtualaragon.es');
+});
+
+test('B3 · el email personal del docente se guarda en centro_docente, no en email_virtual', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C003', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C003']);
+
+    $this->actingAs($usuario)->post('/alta-docente', [
+        'nombre'    => 'Elena',
+        'apellido'  => 'Gómez Torres',
+        'dni'       => '11223344E',
+        'email'     => 'elena.personal@centro.com',
+        'id_centro' => 'C003',
+    ]);
+
+    $docente = Docente::where('dni', '11223344E')->first();
+    // email_virtual NO es el email personal
+    expect($docente->email_virtual)->not->toBe('elena.personal@centro.com');
+    expect($docente->email_virtual)->toEndWith('@fpvirtualaragon.es');
+
+    // El email personal sí está en centro_docente
+    $this->assertDatabaseHas('centro_docente', [
+        'dni'   => '11223344E',
+        'email' => 'elena.personal@centro.com',
+    ]);
+});
+
+test('B4 · si el docente ya existe en BD se respeta su email_virtual original', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C004', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C004']);
+
+    // Crear docente con email_virtual ya asignado
+    Docente::forceCreate([
+        'nombre'        => 'Pedro',
+        'apellido'      => 'López García',
+        'dni'           => '99887766P',
+        'email_virtual' => 'plopezg@fpvirtualaragon.es',
+        'de_baja'       => false,
+    ]);
+
+    // Dar de alta en otro centro
+    $centro2 = Centro::forceCreate(['id_centro' => 'C005', 'nombre' => 'Centro 2']);
+    $this->actingAs($usuario)->post('/alta-docente', [
+        'nombre'    => 'Pedro',
+        'apellido'  => 'López García',
+        'dni'       => '99887766P',
+        'email'     => 'pedro@otro-centro.com',
+        'id_centro' => 'C004',
+    ]);
+
+    // El email_virtual original NO se modifica
+    $docente = Docente::where('dni', '99887766P')->first();
+    expect($docente->email_virtual)->toBe('plopezg@fpvirtualaragon.es');
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE C — Endpoint AJAX previewEmail
+// ════════════════════════════════════════════════════════════════════════════
+
+test('C1 · el endpoint preview-email devuelve el email generado para nombre y apellido', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C010', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C010']);
+
+    $response = $this->actingAs($usuario)
+        ->getJson('/alta-docente/preview-email?nombre=Marta&apellido=Torres Ruiz');
+
+    $response->assertStatus(200)
+             ->assertJson(['email' => 'mtorresr@fpvirtualaragon.es']);
+});
+
+test('C2 · el endpoint preview-email devuelve null si falta el nombre', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C011', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C011']);
+
+    $response = $this->actingAs($usuario)
+        ->getJson('/alta-docente/preview-email?apellido=Torres');
+
+    $response->assertStatus(200)
+             ->assertJson(['email' => null]);
+});
+
+test('C3 · el endpoint preview-email devuelve null si falta el apellido', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C012', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C012']);
+
+    $response = $this->actingAs($usuario)
+        ->getJson('/alta-docente/preview-email?nombre=Marta');
+
+    $response->assertStatus(200)
+             ->assertJson(['email' => null]);
+});
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// BLOQUE D — Colisiones y casos límite
+// ════════════════════════════════════════════════════════════════════════════
+
+test('D1 · si el email generado ya existe se añade sufijo numérico', function () {
+    // Crear docente que "ocupa" el email base
+    Docente::forceCreate([
+        'nombre'        => 'Ana',
+        'apellido'      => 'García López',
+        'dni'           => '11111111A',
+        'email_virtual' => 'agarcial@fpvirtualaragon.es',
+    ]);
+
+    $email = servicio()->generarOObtenerExistente('Ana', 'García López');
+    expect($email)->toBe('agarcial2@fpvirtualaragon.es');
+});
+
+test('D2 · si el email con sufijo 2 también existe prueba con 3', function () {
+    Docente::forceCreate(['nombre'=>'A','apellido'=>'B','dni'=>'11111111X','email_virtual'=>'ab@fpvirtualaragon.es']);
+    Docente::forceCreate(['nombre'=>'A','apellido'=>'B','dni'=>'22222222X','email_virtual'=>'ab2@fpvirtualaragon.es']);
+
+    $email = servicio()->generarOObtenerExistente('A', 'B');
+    expect($email)->toBe('ab3@fpvirtualaragon.es');
+});
+
+test('D3 · generarOObtenerExistente devuelve el email_virtual existente si el docente ya está en BD', function () {
+    Docente::forceCreate([
+        'nombre'        => 'Luis',
+        'apellido'      => 'Pérez Sanz',
+        'dni'           => '55555555L',
+        'email_virtual' => 'lperezs@fpvirtualaragon.es',
+    ]);
+
+    $email = servicio()->generarOObtenerExistente('Luis', 'Pérez Sanz', '55555555L');
+    expect($email)->toBe('lperezs@fpvirtualaragon.es');
+});
+
+test('D4 · comprobarDocente devuelve el email_virtual del docente existente', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'C020', 'nombre' => 'Centro Test']);
+    $usuario = Usuario::factory()->create(['id_centro' => 'C020']);
+
+    Docente::forceCreate([
+        'nombre'        => 'Rosa',
+        'apellido'      => 'Fernández',
+        'dni'           => '66666666R',
+        'email_virtual' => 'rfernandez@fpvirtualaragon.es',
+    ]);
+
+    $response = $this->actingAs($usuario)
+        ->getJson('/comprobar-docente/66666666R');
+
+    $response->assertStatus(200)
+             ->assertJsonPath('email_virtual', 'rfernandez@fpvirtualaragon.es');
+});

--- a/tests/Feature/GestionDocentesUpdateTest.php
+++ b/tests/Feature/GestionDocentesUpdateTest.php
@@ -85,8 +85,8 @@ test('el store no devuelve error de validación cuando el DNI ya existe (upsert)
     $response->assertSessionDoesntHaveErrors(['dni']);
 });
 
-/** 10. UPSERT - El email se actualiza correctamente en la base de datos */
-test('el store actualiza el email_virtual del docente cuando ya existe en BD', function () {
+/** 10. UPSERT - El email_virtual NO se cambia si el docente ya lo tiene asignado (#58) */
+test('el store NO modifica el email_virtual si el docente ya lo tiene asignado', function () {
     $centro = Centro::forceCreate(['id_centro' => 'U300', 'nombre' => 'Centro Update Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'U300']);
 
@@ -94,22 +94,29 @@ test('el store actualiza el email_virtual del docente cuando ya existe en BD', f
         'dni'           => '44444444W',
         'nombre'        => 'Ana',
         'apellido'      => 'Martínez Gil',
-        'email_virtual' => 'ana@viejo.com',
+        'email_virtual' => 'amartinezg@fpvirtualaragon.es',
     ]);
 
     $datos = [
         'dni'      => '44444444W',
         'nombre'   => 'Ana',
         'apellido' => 'Martínez Gil',
-        'email'    => 'ana@nuevo.com',
+        'email'    => 'ana.personal@nuevo.com',  // email personal (va a centro_docente)
         'id_centro' => 'U300',
     ];
 
     $this->actingAs($usuario)->post('/alta-docente', $datos);
 
+    // El email_virtual original se mantiene intacto
     $this->assertDatabaseHas('docentes', [
         'dni'           => '44444444W',
-        'email_virtual' => 'ana@nuevo.com',
+        'email_virtual' => 'amartinezg@fpvirtualaragon.es',
+    ]);
+
+    // El email personal va a centro_docente, no a email_virtual
+    $this->assertDatabaseHas('centro_docente', [
+        'dni'   => '44444444W',
+        'email' => 'ana.personal@nuevo.com',
     ]);
 });
 


### PR DESCRIPTION
## ¿Qué problema resuelve?
Este Pull Request unifica dos necesidades críticas y correlacionadas en la gestión del profesorado:
1. **Issue #58:** La asignación automática de correos institucionales bajo el dominio oficial `@fpvirtualaragon.es` al procesar altas o modificaciones.
2. **Issue #60:** La creación de una interfaz administrativa centralizada para gestionar de forma masiva o individual las altas en plataformas externas (Moodle y Google Workspace).

---

## Cambios realizados por Bloques (Commits)

###  Bloque 1: Correo Institucional (`#58`)
* **Servicio Generador (`app/Services/`):** Implementada la lógica que automatiza la creación de emails virtuales únicos basados en el nombre/apellidos del docente y el dominio corporativo.
* **Refactorización de Formularios:** Modificados el controlador `AltaDocenteController.php` y la vista `alta_docente.blade.php` para que utilicen este servicio y asocien el email virtual correctamente a la ficha del profesor.
* **Pruebas Unitarias:** Creado `GeneradorEmailVirtualTest.php` y actualizados los de integración (`GestionDocentesUpdateTest.php`) para blindar el flujo de datos.

###  Bloque 2: Vista de Altas en Plataforma (`#60`)
* **Migración y Modelo:** Creado el campo `is_procesado` y marcas de tiempo en la tabla de docentes, junto con su mapeo en `Docente.php`.
* **Interfaz de Usuario (`alta_plataforma.blade.php`):** Diseñada una tabla moderna con Tailwind CSS que incluye:
  * Checkboxes para selección múltiple.
  * Alertas visuales dinámicas (Tick verde para estados ya procesados / Equis roja para pendientes).
  * Ventanas emergentes (Pop-ups) individuales para previsualizar los comandos asignados a cada docente.
* **Exportación CSV (Ventana Modal):** Modal interactivo "GENERAR CSVs" que automatiza la descarga de las plantillas estructuradas listas para su importación directa en Moodle y Google Workspace.
* **Lógica AJAX (`AltaPlataformaController.php`):** Sincronización en segundo plano que diferencia el cierre del modal con actualización (cambia estados de rojo a verde en caliente y guarda la fecha) frente a la cancelación sin cambios.

---

## Cómo probar de forma manual
1. Acceder al panel con una cuenta de rol `ADMIN` e ir a la URL `/admin/alta-plataforma`.
2. **Validar #58:** Comprobar que los docentes ya listados cargan con su email `@fpvirtualaragon.es` autogenerado de forma correcta.
3. **Validar Pop-ups (#60):** Pinchar en el icono de detalle de cualquier fila para inspeccionar la ventana emergente con sus comandos asignados.
4. **Validar Descarga Masiva (#60):** Seleccionar varios docentes pendientes, presionar el botón inferior **GENERAR CSVs** y descargar ambos ficheros.
5. **Validar Cambio de Estado (#60):** Presionar el botón **CERRAR Y ACTUALIZAR ESTADO**. El modal se cerrará y verás que las filas seleccionadas mutan dinámicamente a Tick verde con la hora actual de procesamiento.

---

## Cobertura de Tests
Se han ejecutado las pruebas con **Pest** asegurando el correcto funcionamiento de los endpoints implicados, el algoritmo de generación de correos y las transacciones de actualización de estados:
* `tests/Feature/GeneradorEmailVirtualTest.php` 
* `tests/Feature/AltaPlataformaTest.php` 