### PR TITLE
feat: Formato CSV Google Workspace y Moodle + acceso panel admin #61 #62

### DIFF
--- a/app/Http/Controllers/Admin/AltaPlataformaController.php
+++ b/app/Http/Controllers/Admin/AltaPlataformaController.php
@@ -101,26 +101,71 @@ class AltaPlataformaController extends Controller
                             ->whereNotNull('email')->where('email', '!=', '')
                             ->value('email') ?? '';
 
-        // 29 columnas Google Workspace
+        // 29 columnas Google Workspace (#61)
         $googleCols = [
-            $docente->nombre,           // 1  First Name
-            $docente->apellido,         // 2  Last Name
-            $docente->email_virtual,    // 3  Email Address
-            self::PASSWORD_INICIAL,     // 4  Password
-            '',                         // 5  Password Hash Function
-            self::ORG_UNIT,             // 6  Org Unit Path
-            '',                         // 7  New Primary Email
-            $emailPersonal,             // 8  Recovery Email
-            '', '', '', '', '', '', '', '', // 9-16 empty
+            $docente->nombre,           //  1 First Name [Required]
+            $docente->apellido,         //  2 Last Name [Required]
+            $docente->email_virtual,    //  3 Email Address [Required]
+            self::PASSWORD_INICIAL,     //  4 Password [Required]
+            '',                         //  5 Password Hash Function [UPLOAD ONLY]
+            self::ORG_UNIT,             //  6 Org Unit Path [Required]
+            '',                         //  7 New Primary Email [UPLOAD ONLY]
+            $emailPersonal,             //  8 Recovery Email
+            '',                         //  9 Home Secondary Email
+            $emailPersonal,             // 10 Work Secondary Email
+            '',                         // 11 Recovery Phone
+            '',                         // 12 Work Phone
+            '',                         // 13 Home Phone
+            '',                         // 14 Mobile Phone
+            '',                         // 15 Work Address
+            '',                         // 16 Home Address
             $docente->dni,              // 17 Employee ID
-            '', '', '', '', '', '', '', '', // 18-25 empty
+            '',                         // 18 Employee Type
+            '',                         // 19 Employee Title
+            '',                         // 20 Manager Email
+            '',                         // 21 Department
+            '',                         // 22 Cost Center
+            '',                         // 23 Building ID
+            '',                         // 24 Floor Name
+            '',                         // 25 Floor Section
             'TRUE',                     // 26 Change Password at Next Sign-In
-            '', '',                     // 27-28 New Status, New Licenses
+            'Active',                   // 27 New Status [UPLOAD ONLY]
+            '',                         // 28 New Licenses [UPLOAD ONLY]
             'FALSE',                    // 29 Advanced Protection Program enrollment
         ];
 
-        // Moodle: mismo formato de 29 columnas que Google Workspace
-        $moodleCols = $googleCols;
+        // 29 columnas Moodle (#62) — sin Work Secondary Email ni New Status
+        $moodleCols = [
+            $docente->nombre,           //  1 First Name [Required]
+            $docente->apellido,         //  2 Last Name [Required]
+            $docente->email_virtual,    //  3 Email Address [Required]
+            self::PASSWORD_INICIAL,     //  4 Password [Required]
+            '',                         //  5 Password Hash Function [UPLOAD ONLY]
+            self::ORG_UNIT,             //  6 Org Unit Path [Required]
+            '',                         //  7 New Primary Email [UPLOAD ONLY]
+            $emailPersonal,             //  8 Recovery Email
+            '',                         //  9 Home Secondary Email
+            '',                         // 10 Work Secondary Email
+            '',                         // 11 Recovery Phone
+            '',                         // 12 Work Phone
+            '',                         // 13 Home Phone
+            '',                         // 14 Mobile Phone
+            '',                         // 15 Work Address
+            '',                         // 16 Home Address
+            $docente->dni,              // 17 Employee ID
+            '',                         // 18 Employee Type
+            '',                         // 19 Employee Title
+            '',                         // 20 Manager Email
+            '',                         // 21 Department
+            '',                         // 22 Cost Center
+            '',                         // 23 Building ID
+            '',                         // 24 Floor Name
+            '',                         // 25 Floor Section
+            'TRUE',                     // 26 Change Password at Next Sign-In
+            '',                         // 27 New Status [UPLOAD ONLY]
+            '',                         // 28 New Licenses [UPLOAD ONLY]
+            'FALSE',                    // 29 Advanced Protection Program enrollment
+        ];
 
         return response()->json([
             'dni'           => $docente->dni,

--- a/app/Http/Controllers/Admin/AltaPlataformaController.php
+++ b/app/Http/Controllers/Admin/AltaPlataformaController.php
@@ -28,9 +28,16 @@ class AltaPlataformaController extends Controller
         . 'Advanced Protection Program enrollment';
 
     /**
-     * Cabecera del CSV de Moodle.
+     * Cabecera del CSV de Moodle (mismo formato de 29 columnas que Google Workspace).
      */
-    private const MOODLE_HEADER = 'username,firstname,lastname,email';
+    private const MOODLE_HEADER = 'First Name [Required],Last Name [Required],Email Address [Required],'
+        . 'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],'
+        . 'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,'
+        . 'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,'
+        . 'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,'
+        . 'Department,Cost Center,Building ID,Floor Name,Floor Section,'
+        . 'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],'
+        . 'Advanced Protection Program enrollment';
 
     // ── index ─────────────────────────────────────────────────────────────────
 
@@ -112,13 +119,8 @@ class AltaPlataformaController extends Controller
             'FALSE',                    // 29 Advanced Protection Program enrollment
         ];
 
-        // 4 columnas Moodle
-        $moodleCols = [
-            '"prof' . $docente->dni . '"',
-            '"' . $docente->nombre . '"',
-            '"' . $docente->apellido . '"',
-            '"' . $docente->email_virtual . '"',
-        ];
+        // Moodle: mismo formato de 29 columnas que Google Workspace
+        $moodleCols = $googleCols;
 
         return response()->json([
             'dni'           => $docente->dni,

--- a/app/Http/Controllers/Admin/AltaPlataformaController.php
+++ b/app/Http/Controllers/Admin/AltaPlataformaController.php
@@ -3,15 +3,37 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\CentroDocente;
 use App\Models\Docente;
 use Illuminate\Http\Request;
 
 class AltaPlataformaController extends Controller
 {
+    /** Contraseña inicial fija para todos los docentes de Google Workspace */
+    private const PASSWORD_INICIAL = 'Cambiam3!_';
+
+    /** Unidad organizativa en Google Workspace */
+    private const ORG_UNIT = '/Profesorado';
+
     /**
-     * Listado de docentes pendientes/procesados para dar de alta en plataformas.
-     * Excluye los que están de baja y los que no tienen email_virtual aún.
+     * Cabecera oficial del CSV de Google Workspace (29 columnas).
      */
+    private const GOOGLE_HEADER = 'First Name [Required],Last Name [Required],Email Address [Required],'
+        . 'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],'
+        . 'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,'
+        . 'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,'
+        . 'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,'
+        . 'Department,Cost Center,Building ID,Floor Name,Floor Section,'
+        . 'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],'
+        . 'Advanced Protection Program enrollment';
+
+    /**
+     * Cabecera del CSV de Moodle.
+     */
+    private const MOODLE_HEADER = 'username,firstname,lastname,email';
+
+    // ── index ─────────────────────────────────────────────────────────────────
+
     public function index(Request $request)
     {
         $query = Docente::query()
@@ -19,7 +41,6 @@ class AltaPlataformaController extends Controller
             ->whereNotNull('email_virtual')
             ->where('email_virtual', '!=', '');
 
-        // Filtro por estado
         if ($request->filled('estado')) {
             if ($request->estado === 'pendiente') {
                 $query->where('is_procesado', false);
@@ -28,7 +49,6 @@ class AltaPlataformaController extends Controller
             }
         }
 
-        // Búsqueda por nombre, apellido o DNI
         if ($request->filled('buscar')) {
             $buscar = $request->buscar;
             $query->where(function ($q) use ($buscar) {
@@ -40,55 +60,81 @@ class AltaPlataformaController extends Controller
 
         $docentes = $query->clone()->orderBy('apellido')->orderBy('nombre')->paginate(20)->withQueryString();
 
-        // Embed all docente data as JSON for client-side CSV generation
-        // Use clone() so paginate()'s LIMIT/OFFSET don't bleed into this query
-        $docentesJson = $query->clone()->orderBy('apellido')->orderBy('nombre')->get()->map(function ($d) {
-            return [
-                'id'            => $d->id,
-                'dni'           => $d->dni,
-                'nombre'        => $d->nombre,
-                'apellido'      => $d->apellido,
-                'email_virtual' => $d->email_virtual,
-                'is_procesado'  => $d->is_procesado,
+        // Cargamos emails personales en bloque (evita N+1)
+        $dnis = $query->clone()->pluck('dni');
+        $emailsByDni = CentroDocente::whereIn('dni', $dnis)
+            ->whereNotNull('email')
+            ->where('email', '!=', '')
+            ->orderBy('id_centro')
+            ->get()
+            ->groupBy('dni')
+            ->map(fn($items) => $items->first()->email);
+
+        $docentesJson = $query->clone()->orderBy('apellido')->orderBy('nombre')->get()
+            ->map(fn($d) => [
+                'id'             => $d->id,
+                'dni'            => $d->dni,
+                'nombre'         => $d->nombre,
+                'apellido'       => $d->apellido,
+                'email_virtual'  => $d->email_virtual,
+                'email_personal' => $emailsByDni[$d->dni] ?? '',
+                'is_procesado'   => $d->is_procesado,
                 'fecha_procesado' => $d->fecha_procesado?->format('d/m/Y H:i'),
-            ];
-        });
+            ]);
 
         return view('admin.alta_plataforma', compact('docentes', 'docentesJson'));
     }
 
-    /**
-     * AJAX — Previsualización de la línea CSV para un docente.
-     */
+    // ── preview ───────────────────────────────────────────────────────────────
+
     public function preview(int $id)
     {
-        $docente = Docente::findOrFail($id);
+        $docente       = Docente::findOrFail($id);
+        $emailPersonal = CentroDocente::where('dni', $docente->dni)
+                            ->whereNotNull('email')->where('email', '!=', '')
+                            ->value('email') ?? '';
 
-        $local = explode('@', $docente->email_virtual)[0] ?? $docente->email_virtual;
+        // 29 columnas Google Workspace
+        $googleCols = [
+            $docente->nombre,           // 1  First Name
+            $docente->apellido,         // 2  Last Name
+            $docente->email_virtual,    // 3  Email Address
+            self::PASSWORD_INICIAL,     // 4  Password
+            '',                         // 5  Password Hash Function
+            self::ORG_UNIT,             // 6  Org Unit Path
+            '',                         // 7  New Primary Email
+            $emailPersonal,             // 8  Recovery Email
+            '', '', '', '', '', '', '', '', // 9-16 empty
+            $docente->dni,              // 17 Employee ID
+            '', '', '', '', '', '', '', '', // 18-25 empty
+            'TRUE',                     // 26 Change Password at Next Sign-In
+            '', '',                     // 27-28 New Status, New Licenses
+            'FALSE',                    // 29 Advanced Protection Program enrollment
+        ];
+
+        // 4 columnas Moodle
+        $moodleCols = [
+            '"prof' . $docente->dni . '"',
+            '"' . $docente->nombre . '"',
+            '"' . $docente->apellido . '"',
+            '"' . $docente->email_virtual . '"',
+        ];
 
         return response()->json([
             'dni'           => $docente->dni,
             'nombre'        => $docente->nombre,
             'apellido'      => $docente->apellido,
             'email_virtual' => $docente->email_virtual,
-            'google_csv'    => implode(',', [
-                $docente->nombre . ' ' . $docente->apellido,
-                $docente->email_virtual,
-                '',  // Password (vacío — se generará)
-                '',  // Org unit
-            ]),
-            'moodle_csv'    => implode(',', [
-                '"prof' . $docente->dni . '"',  // username
-                '"' . $docente->nombre . '"',   // firstname (nombre_normalizado)
-                '"' . $docente->apellido . '"', // lastname (apellido_normalizado)
-                '"' . $docente->email_virtual . '"', // email
-            ]),
+            'email_personal' => $emailPersonal,
+            'google_csv'    => implode(',', $googleCols),
+            'moodle_csv'    => implode(',', $moodleCols),
+            'google_header' => self::GOOGLE_HEADER,
+            'moodle_header' => self::MOODLE_HEADER,
         ]);
     }
 
-    /**
-     * Marcar los docentes seleccionados como procesados.
-     */
+    // ── procesarAltas ─────────────────────────────────────────────────────────
+
     public function procesarAltas(Request $request)
     {
         $request->validate([
@@ -99,7 +145,7 @@ class AltaPlataformaController extends Controller
         Docente::whereIn('id', $request->ids)
             ->where('de_baja', false)
             ->update([
-                'is_procesado'   => true,
+                'is_procesado'    => true,
                 'fecha_procesado' => now(),
             ]);
 

--- a/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -11,6 +11,9 @@ class LoginController extends Controller
 {
     public function showLoginForm()
     {
+        if (Auth::guard('admin')->check()) {
+            return redirect()->route('admin.dashboard');
+        }
         return view('admin.login');
     }
 
@@ -21,11 +24,11 @@ class LoginController extends Controller
             'password' => ['required', 'string'],
         ]);
 
-        // Intentar login por nombre
+        // Intentar login por nombre (remember=true para persistir entre sesiones de usuario)
         $loginByName = Auth::guard('admin')->attempt([
-            'nombre' => $credentials['user'],
+            'user' => $credentials['user'],
             'password' => $credentials['password']
-        ], $request->boolean('remember'));
+        ], true);
 
         // Intentar login por email si el anterior falla
         $loginByEmail = false;
@@ -33,7 +36,7 @@ class LoginController extends Controller
             $loginByEmail = Auth::guard('admin')->attempt([
                 'email' => $credentials['user'],
                 'password' => $credentials['password']
-            ], $request->boolean('remember'));
+            ], true);
         }
 
         if ($loginByName || $loginByEmail) {

--- a/app/Http/Controllers/Admin/DocenteController.php
+++ b/app/Http/Controllers/Admin/DocenteController.php
@@ -161,7 +161,7 @@ class DocenteController extends Controller
                 'modulos_por_centro' => array_values($modulosPorCentro),
                 'todos_los_modulos' => $todosLosModulos,
                 'tutorias' => $tutorias,
-                'coordinaciones' => $coordinaciones
+                'coordinaciones' => $coordinaciones,
             ]);
 
             

--- a/app/Http/Middleware/EsAdmin.php
+++ b/app/Http/Middleware/EsAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Admin;
+use Closure;
+use Illuminate\Http\Request;
+
+class EsAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!auth()->check() || !Admin::where('email', auth()->user()->email)->exists()) {
+            abort(403, 'Acceso restringido a administradores.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EsAdmin.php
+++ b/app/Http/Middleware/EsAdmin.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Models\Admin;
 use Closure;
 use Illuminate\Http\Request;
 
@@ -10,7 +9,7 @@ class EsAdmin
 {
     public function handle(Request $request, Closure $next)
     {
-        if (!auth()->check() || !Admin::where('email', auth()->user()->email)->exists()) {
+        if (!auth()->check() || !auth()->user()->is_admin) {
             abort(403, 'Acceso restringido a administradores.');
         }
 

--- a/app/Models/Usuario.php
+++ b/app/Models/Usuario.php
@@ -26,7 +26,7 @@ class Usuario extends Authenticatable
         'nombre',
         'email',
         'password',
-
+        'is_admin',
     ];
 
     /**
@@ -48,6 +48,7 @@ class Usuario extends Authenticatable
     {
         return [
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'es_admin' => \App\Http\Middleware\EsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (AuthenticationException $e, Request $request) {

--- a/config/auth.php
+++ b/config/auth.php
@@ -43,7 +43,7 @@ return [
 
         'admin' => [
             'driver' => 'session',
-            'provider' => 'users',
+            'provider' => 'admins',
         ],
     ],
 
@@ -71,10 +71,10 @@ return [
         ],
 
 
-        // 'admins' => [
-        //     'driver' => 'eloquent',
-        //     'model' => App\Models\Admin::class,
-        // ],
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
+        ],
         // 'users' => [
         //     'driver' => 'database',
         //     'table' => 'users',

--- a/database/migrations/2025_05_26_000001_add_is_admin_to_usuario_table.php
+++ b/database/migrations/2025_05_26_000001_add_is_admin_to_usuario_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('usuario', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('usuario', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/database/seeders/UsuarioSeeder.php
+++ b/database/seeders/UsuarioSeeder.php
@@ -22,6 +22,7 @@ public function run()
             'nombre' => 'Admin',
             'email' => 'admin@gmail.com',
             'password' =>  Hash::make('12345678'),
+            'is_admin' => true,
             
         ],
         [

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -18,12 +18,12 @@
     .btn-success   { background:#16a34a; color:#fff; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
     .btn-success:hover   { background:#15803d; }
     .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:40; display:flex; align-items:center; justify-content:center; }
-    .modal-box     { background:#fff; border-radius:12px; padding:2rem; max-width:560px; width:90%; box-shadow:0 8px 32px rgba(0,0,0,.18); }
+    .modal-box     { background:#fff; border-radius:12px; padding:2rem; max-width:620px; width:90%; box-shadow:0 8px 32px rgba(0,0,0,.18); }
     .modal-title   { font-size:1.1rem; font-weight:700; color:#1e3a5f; margin-bottom:1rem; }
-    .csv-preview   { background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px; padding:.75rem 1rem; font-family:monospace; font-size:.8rem; word-break:break-all; color:#334155; margin-bottom:.5rem; }
+    .csv-preview   { background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px; padding:.75rem 1rem; font-family:monospace; font-size:.75rem; word-break:break-all; color:#334155; margin-bottom:.5rem; }
     .divider       { border:none; border-top:1px solid #e2e8f0; margin:1.25rem 0; }
-    .tick-ok       { color:#16a34a; font-size:.9rem; font-weight:600; }
-    .tick-no       { color:#dc2626; font-size:.9rem; font-weight:600; }
+    .tick-ok       { color:#16a34a; font-size:.88rem; font-weight:600; }
+    .tick-no       { color:#dc2626; font-size:.88rem; font-weight:600; }
 </style>
 @endpush
 
@@ -65,17 +65,12 @@
                 @forelse($docentes as $docente)
                 <tr>
                     <td>
-                        <input type="checkbox"
-                               value="{{ $docente->id }}"
-                               x-model="selected"
-                               @change="syncCheckAll">
+                        <input type="checkbox" value="{{ $docente->id }}" x-model="selected" @change="syncCheckAll">
                     </td>
                     <td class="font-mono text-xs">{{ $docente->dni }}</td>
                     <td>{{ $docente->nombre }}</td>
                     <td>{{ $docente->apellido }}</td>
                     <td class="text-indigo-700 font-medium text-xs">{{ $docente->email_virtual }}</td>
-
-                    {{-- Estado: reactivo vía Alpine --}}
                     <td>
                         <span x-show="getEstado({{ $docente->id }})" class="tick-ok">
                             <i class="fas fa-check-circle"></i> Exportado
@@ -84,12 +79,7 @@
                             <i class="fas fa-times-circle"></i> Pendiente
                         </span>
                     </td>
-
-                    {{-- Fecha: reactiva vía Alpine --}}
-                    <td class="text-xs text-gray-500"
-                        x-text="getFecha({{ $docente->id }})">
-                    </td>
-
+                    <td class="text-xs text-gray-500" x-text="getFecha({{ $docente->id }})"></td>
                     <td>
                         <button class="text-indigo-600 hover:text-indigo-800 text-xs font-semibold"
                                 @click="verDetalle({{ $docente->id }})">
@@ -106,10 +96,7 @@
         </table>
     </div>
 
-    {{-- Paginación --}}
-    <div class="mt-4">
-        {{ $docentes->links() }}
-    </div>
+    <div class="mt-4">{{ $docentes->links() }}</div>
 
     {{-- Botón generar CSVs --}}
     <div class="mt-6 flex items-center gap-4">
@@ -124,7 +111,7 @@
 
     {{-- Modal: previsualización CSV de un docente --}}
     <div class="modal-overlay" x-show="showPreview" x-cloak @click.self="showPreview = false">
-        <div class="modal-box">
+        <div class="modal-box" style="max-width:680px;">
             <h4 class="modal-title"><i class="fas fa-eye mr-2 text-indigo-500"></i>Previsualización CSV</h4>
             <template x-if="previewDocente">
                 <div>
@@ -132,9 +119,9 @@
                         <strong x-text="previewDocente.nombre + ' ' + previewDocente.apellido"></strong>
                         &nbsp;|&nbsp; <span class="font-mono text-xs" x-text="previewDocente.dni"></span>
                     </p>
-                    <p class="text-xs font-semibold text-gray-500 mb-1">Google Workspace CSV:</p>
+                    <p class="text-xs font-semibold text-gray-500 mb-1">Google Workspace:</p>
                     <div class="csv-preview" x-text="csvLineGoogle(previewDocente)"></div>
-                    <p class="text-xs font-semibold text-gray-500 mb-1 mt-3">Moodle CSV:</p>
+                    <p class="text-xs font-semibold text-gray-500 mb-1 mt-3">Moodle:</p>
                     <div class="csv-preview" x-text="csvLineMoodle(previewDocente)"></div>
                 </div>
             </template>
@@ -150,14 +137,12 @@
             <h4 class="modal-title">
                 <i class="fas fa-file-download mr-2 text-indigo-500"></i>Exportar CSVs
             </h4>
-
             <p class="text-sm text-gray-600 mb-4">
                 Descarga los ficheros para
                 <strong x-text="selectedDocentes().length"></strong>
                 docente(s) seleccionado(s) y, cuando estés listo/a, cierra actualizando el estado.
             </p>
 
-            {{-- Botones de descarga --}}
             <div class="flex flex-wrap gap-3 mb-2">
                 <button class="btn-primary" @click="downloadCSV('google')">
                     <i class="fab fa-google mr-1"></i>Descargar CSV Google Workspace
@@ -169,7 +154,6 @@
 
             <hr class="divider">
 
-            {{-- Botones de cierre --}}
             <div class="flex flex-wrap justify-between items-center gap-3">
                 <button class="btn-secondary" @click="cerrarSinActualizar()">
                     <i class="fas fa-times mr-1"></i>Cerrar sin actualizar estado
@@ -178,12 +162,8 @@
                         :disabled="procesando"
                         :class="{ 'opacity-60 cursor-not-allowed': procesando }"
                         @click="cerrarActualizando()">
-                    <span x-show="!procesando">
-                        <i class="fas fa-check-circle mr-1"></i>Cerrar y actualizar estado
-                    </span>
-                    <span x-show="procesando">
-                        <i class="fas fa-spinner fa-spin mr-1"></i>Actualizando…
-                    </span>
+                    <span x-show="!procesando"><i class="fas fa-check-circle mr-1"></i>Cerrar y actualizar estado</span>
+                    <span x-show="procesando"><i class="fas fa-spinner fa-spin mr-1"></i>Actualizando…</span>
                 </button>
             </div>
         </div>
@@ -201,64 +181,81 @@ document.addEventListener('alpine:init', () => {
         procesando: false,
         docenteMap: @json($docentesJson),
 
-        // ── Helpers de estado reactivo ─────────────────────────────────
+        // ── Estado reactivo ────────────────────────────────────────────
         getEstado(id) {
             return this.docenteMap.find(d => d.id === id)?.is_procesado ?? false;
         },
-
         getFecha(id) {
             return this.docenteMap.find(d => d.id === id)?.fecha_procesado ?? '—';
         },
 
         // ── Selección ──────────────────────────────────────────────────
         toggleAll(event) {
-            if (event.target.checked) {
-                this.selected = this.docenteMap.map(d => d.id);
-            } else {
-                this.selected = [];
-            }
+            this.selected = event.target.checked ? this.docenteMap.map(d => d.id) : [];
         },
-
         syncCheckAll() {
             const allIds = this.docenteMap.map(d => d.id);
             this.$refs.checkAll.checked = allIds.length > 0 && allIds.every(id => this.selected.includes(id));
             this.$refs.checkAll.indeterminate = this.selected.length > 0 && !this.$refs.checkAll.checked;
         },
-
         selectedDocentes() {
             return this.docenteMap.filter(d => this.selected.includes(d.id));
         },
 
-        // ── Detalle / preview ──────────────────────────────────────────
         verDetalle(id) {
             this.previewDocente = this.docenteMap.find(d => d.id === id) ?? null;
             this.showPreview = true;
         },
-
         abrirExport() {
             if (this.selected.length === 0) return;
             this.showExport = true;
         },
 
-        // ── Generación CSV ─────────────────────────────────────────────
+        // ── Google Workspace CSV (29 columnas) ─────────────────────────
         csvLineGoogle(d) {
-            const nombre = (d.nombre + ' ' + d.apellido).replace(/"/g, '""');
-            return `"${nombre}","${d.email_virtual}",,`;
+            const cols = [
+                d.nombre          || '',   //  1 First Name [Required]
+                d.apellido        || '',   //  2 Last Name [Required]
+                d.email_virtual   || '',   //  3 Email Address [Required]
+                'Cambiam3!_',              //  4 Password [Required]
+                '',                        //  5 Password Hash Function [UPLOAD ONLY]
+                '/Profesorado',            //  6 Org Unit Path [Required]
+                '',                        //  7 New Primary Email [UPLOAD ONLY]
+                d.email_personal  || '',   //  8 Recovery Email
+                '', '', '', '', '', '', '', '', //  9-16 vacías
+                d.dni             || '',   // 17 Employee ID
+                '', '', '', '', '', '', '', '', // 18-25 vacías
+                'TRUE',                    // 26 Change Password at Next Sign-In
+                '', '',                    // 27-28 New Status, New Licenses
+                'FALSE',                   // 29 Advanced Protection Program enrollment
+            ];
+            return cols.join(',');
         },
 
+        // ── Moodle CSV (4 columnas) ────────────────────────────────────
         csvLineMoodle(d) {
-            const user    = 'prof' + d.dni;
-            const nombre  = (d.nombre  || '').replace(/"/g, '""');
+            const user     = 'prof' + (d.dni || '');
+            const nombre   = (d.nombre   || '').replace(/"/g, '""');
             const apellido = (d.apellido || '').replace(/"/g, '""');
-            return `"${user}","${nombre}","${apellido}","${d.email_virtual}"`;
+            return `"${user}","${nombre}","${apellido}","${d.email_virtual || ''}"`;
         },
 
+        // ── Descarga ───────────────────────────────────────────────────
         downloadCSV(tipo) {
-            const docs = this.selectedDocentes();
-            let lines  = [];
+            const docs  = this.selectedDocentes();
+            let   lines = [];
 
             if (tipo === 'google') {
-                lines.push('Nombre,Correo,Contraseña,Unidad organizativa');
+                lines.push(
+                    'First Name [Required],Last Name [Required],Email Address [Required],' +
+                    'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],' +
+                    'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,' +
+                    'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,' +
+                    'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,' +
+                    'Department,Cost Center,Building ID,Floor Name,Floor Section,' +
+                    'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],' +
+                    'Advanced Protection Program enrollment'
+                );
                 docs.forEach(d => lines.push(this.csvLineGoogle(d)));
             } else {
                 lines.push('username,firstname,lastname,email');
@@ -275,7 +272,7 @@ document.addEventListener('alpine:init', () => {
             URL.revokeObjectURL(url);
         },
 
-        // ── Botones de cierre del modal ────────────────────────────────
+        // ── Cierre del modal ───────────────────────────────────────────
         cerrarSinActualizar() {
             this.showExport = false;
         },
@@ -283,44 +280,30 @@ document.addEventListener('alpine:init', () => {
         cerrarActualizando() {
             if (this.procesando) return;
             this.procesando = true;
-
-            const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
-            const idsAmarcar = [...this.selected];
+            const token       = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+            const idsAmarcar  = [...this.selected];
 
             fetch('{{ route("admin.alta-plataforma.procesar") }}', {
                 method:  'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': token,
-                    'Accept':       'application/json',
-                },
-                body: JSON.stringify({ ids: idsAmarcar }),
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': token, 'Accept': 'application/json' },
+                body:    JSON.stringify({ ids: idsAmarcar }),
             })
             .then(r => r.ok ? r.json() : Promise.reject(r))
             .then(() => {
-                // Actualizar estado en el docenteMap local (sin recargar página)
                 const ahora = new Date().toLocaleString('es-ES', {
                     day: '2-digit', month: '2-digit', year: 'numeric',
                     hour: '2-digit', minute: '2-digit',
                 });
                 idsAmarcar.forEach(id => {
                     const d = this.docenteMap.find(d => d.id === id);
-                    if (d) {
-                        d.is_procesado   = true;
-                        d.fecha_procesado = ahora;
-                    }
+                    if (d) { d.is_procesado = true; d.fecha_procesado = ahora; }
                 });
-
                 this.showExport = false;
                 this.selected   = [];
                 if (this.$refs.checkAll) this.$refs.checkAll.checked = false;
             })
-            .catch(() => {
-                alert('Error al actualizar el estado. Inténtalo de nuevo.');
-            })
-            .finally(() => {
-                this.procesando = false;
-            });
+            .catch(() => alert('Error al actualizar el estado. Inténtalo de nuevo.'))
+            .finally(() => { this.procesando = false; });
         },
     }));
 });

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -232,12 +232,9 @@ document.addEventListener('alpine:init', () => {
             return cols.join(',');
         },
 
-        // ── Moodle CSV (4 columnas) ────────────────────────────────────
+        // ── Moodle CSV (29 columnas — mismo formato que Google Workspace) ─
         csvLineMoodle(d) {
-            const user     = 'prof' + (d.dni || '');
-            const nombre   = (d.nombre   || '').replace(/"/g, '""');
-            const apellido = (d.apellido || '').replace(/"/g, '""');
-            return `"${user}","${nombre}","${apellido}","${d.email_virtual || ''}"`;
+            return this.csvLineGoogle(d);
         },
 
         // ── Descarga ───────────────────────────────────────────────────

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -3,170 +3,157 @@
 @section('content')
 
 @push('styles')
+<link rel="stylesheet" href="{{ asset('css/establecerCoordinadorTutorDocencia.css') }}">
 <style>
-    .ap-panel      { background:#fff; border-radius:12px; box-shadow:0 2px 12px rgba(0,0,0,.08); padding:2rem; margin:2rem auto; max-width:1100px; }
-    .ap-title      { font-size:1.4rem; font-weight:700; color:#1e3a5f; margin-bottom:.25rem; }
-    .ap-subtitle   { font-size:.9rem; color:#64748b; margin-bottom:1.5rem; }
-    .ap-table      { width:100%; border-collapse:collapse; font-size:.9rem; }
-    .ap-table th   { background:#f1f5f9; color:#475569; text-align:left; padding:.6rem .8rem; border-bottom:2px solid #e2e8f0; }
-    .ap-table td   { padding:.55rem .8rem; border-bottom:1px solid #f1f5f9; vertical-align:middle; }
-    .ap-table tr:hover td { background:#f8fafc; }
-    .btn-primary   { background:#4f46e5; color:#fff; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
-    .btn-primary:hover   { background:#4338ca; }
-    .btn-secondary { background:#e2e8f0; color:#334155; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
-    .btn-secondary:hover { background:#cbd5e1; }
-    .btn-success   { background:#16a34a; color:#fff; border:none; border-radius:8px; padding:.5rem 1.2rem; cursor:pointer; font-size:.9rem; font-weight:600; transition:background .2s; }
-    .btn-success:hover   { background:#15803d; }
-    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:40; display:flex; align-items:center; justify-content:center; }
-    .modal-box     { background:#fff; border-radius:12px; padding:2rem; max-width:620px; width:90%; box-shadow:0 8px 32px rgba(0,0,0,.18); }
-    .modal-title   { font-size:1.1rem; font-weight:700; color:#1e3a5f; margin-bottom:1rem; }
-    .csv-preview   { background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px; padding:.75rem 1rem; font-family:monospace; font-size:.75rem; word-break:break-all; color:#334155; margin-bottom:.5rem; }
-    .divider       { border:none; border-top:1px solid #e2e8f0; margin:1.25rem 0; }
-    .tick-ok       { color:#16a34a; font-size:.88rem; font-weight:600; }
-    .tick-no       { color:#dc2626; font-size:.88rem; font-weight:600; }
+    .csv-preview { background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px; padding:.75rem 1rem; font-family:monospace; font-size:.75rem; word-break:break-all; color:#334155; margin-bottom:.5rem; }
+    .tick-ok     { color:#16a34a; font-size:.88rem; font-weight:600; }
+    .tick-no     { color:#dc2626; font-size:.88rem; font-weight:600; }
+    .divider     { border:none; border-top:1px solid #e2e8f0; margin:1.25rem 0; }
+    .button-success { background-color:#16a34a; color:white; }
+    .button-success:hover { background-color:#15803d; transform:translateY(-2px); }
 </style>
 @endpush
 
-<div class="ap-panel" x-data="altaPlataforma()">
+<div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8" x-data="altaPlataforma()">
 
-    <h3 class="ap-title"><i class="fas fa-cloud-upload-alt mr-2 text-indigo-600"></i>Alta en Plataforma</h3>
-    <p class="ap-subtitle">Selecciona los docentes para generar los CSV de Google Workspace y Moodle.</p>
+        <div class="panel">
+            <h3 class="title">Alta en Plataforma</h3>
+            <p class="subtitle">Selecciona los docentes para generar los CSV de Google Workspace y Moodle.</p>
 
-    {{-- Filtros --}}
-    <form method="GET" action="{{ route('admin.alta-plataforma') }}" class="flex flex-wrap gap-3 mb-5">
-        <input type="text" name="buscar" value="{{ request('buscar') }}"
-               placeholder="Buscar por nombre, apellido o DNI..."
-               class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300 w-64">
-        <select name="estado" class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300">
-            <option value="">— Todos los estados —</option>
-            <option value="pendiente" @selected(request('estado') === 'pendiente')>Pendiente de alta</option>
-            <option value="procesado" @selected(request('estado') === 'procesado')>Procesado</option>
-        </select>
-        <button type="submit" class="btn-secondary"><i class="fas fa-search mr-1"></i> Filtrar</button>
-        <a href="{{ route('admin.alta-plataforma') }}" class="btn-secondary"><i class="fas fa-times mr-1"></i> Limpiar</a>
-    </form>
+            {{-- Filtros --}}
+            <form method="GET" action="{{ route('admin.alta-plataforma') }}" class="flex flex-wrap gap-3 mb-5">
+                <input type="text" name="buscar" value="{{ request('buscar') }}"
+                       placeholder="Buscar por nombre, apellido o DNI..."
+                       class="input" style="max-width:280px;">
+                <select name="estado" class="select" style="max-width:220px;">
+                    <option value="">— Todos los estados —</option>
+                    <option value="pendiente" @selected(request('estado') === 'pendiente')>Pendiente de alta</option>
+                    <option value="procesado" @selected(request('estado') === 'procesado')>Procesado</option>
+                </select>
+                <button type="submit" class="button button-secondary button-tiny">
+                    <i class="fas fa-search mr-1"></i> Filtrar
+                </button>
+                <a href="{{ route('admin.alta-plataforma') }}" class="button button-secondary button-tiny">
+                    <i class="fas fa-times mr-1"></i> Limpiar
+                </a>
+            </form>
 
-    {{-- Tabla --}}
-    <div class="overflow-x-auto">
-        <table class="ap-table">
-            <thead>
-                <tr>
-                    <th><input type="checkbox" @change="toggleAll($event)" x-ref="checkAll"></th>
-                    <th>DNI</th>
-                    <th>Nombre</th>
-                    <th>Apellidos</th>
-                    <th>Email @fpvirtualaragon.es</th>
-                    <th>Estado exportación</th>
-                    <th>Fecha exportación</th>
-                    <th>Ver CSV</th>
-                </tr>
-            </thead>
-            <tbody>
-                @forelse($docentes as $docente)
-                <tr>
-                    <td>
-                        <input type="checkbox" value="{{ $docente->id }}" x-model="selected" @change="syncCheckAll">
-                    </td>
-                    <td class="font-mono text-xs">{{ $docente->dni }}</td>
-                    <td>{{ $docente->nombre }}</td>
-                    <td>{{ $docente->apellido }}</td>
-                    <td class="text-indigo-700 font-medium text-xs">{{ $docente->email_virtual }}</td>
-                    <td>
-                        <span x-show="getEstado({{ $docente->id }})" class="tick-ok">
-                            <i class="fas fa-check-circle"></i> Exportado
-                        </span>
-                        <span x-show="!getEstado({{ $docente->id }})" class="tick-no">
-                            <i class="fas fa-times-circle"></i> Pendiente
-                        </span>
-                    </td>
-                    <td class="text-xs text-gray-500" x-text="getFecha({{ $docente->id }})"></td>
-                    <td>
-                        <button class="text-indigo-600 hover:text-indigo-800 text-xs font-semibold"
-                                @click="verDetalle({{ $docente->id }})">
-                            <i class="fas fa-eye mr-1"></i>Ver CSV
-                        </button>
-                    </td>
-                </tr>
-                @empty
-                <tr>
-                    <td colspan="8" class="text-center text-gray-400 py-8">No hay docentes que coincidan con los filtros.</td>
-                </tr>
-                @endforelse
-            </tbody>
-        </table>
-    </div>
+            {{-- Tabla --}}
+            <div class="table-container">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th><input type="checkbox" @change="toggleAll($event)" x-ref="checkAll"></th>
+                            <th>DNI</th>
+                            <th>Nombre</th>
+                            <th>Apellidos</th>
+                            <th>Email @fpvirtualaragon.es</th>
+                            <th>Estado exportación</th>
+                            <th>Fecha exportación</th>
+                            <th>Ver CSV</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($docentes as $docente)
+                        <tr>
+                            <td><input type="checkbox" value="{{ $docente->id }}" x-model="selected" @change="syncCheckAll"></td>
+                            <td>{{ $docente->dni }}</td>
+                            <td>{{ $docente->nombre }}</td>
+                            <td>{{ $docente->apellido }}</td>
+                            <td>{{ $docente->email_virtual }}</td>
+                            <td>
+                                <span x-show="getEstado({{ $docente->id }})" class="tick-ok"><i class="fas fa-check-circle"></i> Exportado</span>
+                                <span x-show="!getEstado({{ $docente->id }})" class="tick-no"><i class="fas fa-times-circle"></i> Pendiente</span>
+                            </td>
+                            <td x-text="getFecha({{ $docente->id }})"></td>
+                            <td>
+                                <button class="button button-secondary button-tiny" @click="verDetalle({{ $docente->id }})">
+                                    <i class="fas fa-eye mr-1"></i>Ver CSV
+                                </button>
+                            </td>
+                        </tr>
+                        @empty
+                        <tr>
+                            <td colspan="8" class="table-empty">No hay docentes que coincidan con los filtros.</td>
+                        </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
 
-    <div class="mt-4">{{ $docentes->links() }}</div>
+            <div class="mt-4">{{ $docentes->links() }}</div>
 
-    {{-- Botón generar CSVs --}}
-    <div class="mt-6 flex items-center gap-4">
-        <span class="text-sm text-gray-500" x-text="selected.length + ' docente(s) seleccionado(s)'"></span>
-        <button class="btn-primary"
-                :disabled="selected.length === 0"
-                :class="{ 'opacity-50 cursor-not-allowed': selected.length === 0 }"
-                @click="abrirExport()">
-            <i class="fas fa-file-csv mr-2"></i>Generar CSVs
-        </button>
-    </div>
+            {{-- Botón generar CSVs --}}
+            <div class="mt-6 flex items-center gap-4">
+                <span class="text-sm text-gray-500" x-text="selected.length + ' docente(s) seleccionado(s)'"></span>
+                <button class="button button-primary"
+                        :disabled="selected.length === 0"
+                        :class="{ 'opacity-50 cursor-not-allowed': selected.length === 0 }"
+                        @click="abrirExport()">
+                    <i class="fas fa-file-csv mr-2"></i>Generar CSVs
+                </button>
+            </div>
+        </div>
 
-    {{-- Modal: previsualización CSV de un docente --}}
-    <div class="modal-overlay" x-show="showPreview" x-cloak @click.self="showPreview = false">
-        <div class="modal-box" style="max-width:680px;">
-            <h4 class="modal-title"><i class="fas fa-eye mr-2 text-indigo-500"></i>Previsualización CSV</h4>
-            <template x-if="previewDocente">
-                <div>
-                    <p class="text-sm text-gray-600 mb-3">
-                        <strong x-text="previewDocente.nombre + ' ' + previewDocente.apellido"></strong>
-                        &nbsp;|&nbsp; <span class="font-mono text-xs" x-text="previewDocente.dni"></span>
-                    </p>
-                    <p class="text-xs font-semibold text-gray-500 mb-1">Google Workspace:</p>
-                    <div class="csv-preview" x-text="csvLineGoogle(previewDocente)"></div>
-                    <p class="text-xs font-semibold text-gray-500 mb-1 mt-3">Moodle:</p>
-                    <div class="csv-preview" x-text="csvLineMoodle(previewDocente)"></div>
+        {{-- Modal: previsualización CSV de un docente --}}
+        <div class="modal" x-show="showPreview" x-cloak @click.self="showPreview = false">
+            <div class="modal-content" style="max-width:680px;">
+                <h4 class="modal-title">Previsualización CSV</h4>
+                <template x-if="previewDocente">
+                    <div>
+                        <p class="modal-text">
+                            <strong x-text="previewDocente.nombre + ' ' + previewDocente.apellido"></strong>
+                            &nbsp;|&nbsp; <span x-text="previewDocente.dni"></span>
+                        </p>
+                        <p class="label">Google Workspace:</p>
+                        <div class="csv-preview" x-text="csvLineGoogle(previewDocente)"></div>
+                        <p class="label mt-3">Moodle:</p>
+                        <div class="csv-preview" x-text="csvLineMoodle(previewDocente)"></div>
+                    </div>
+                </template>
+                <div class="modal-actions">
+                    <button class="button button-secondary" @click="showPreview = false">Cerrar</button>
                 </div>
-            </template>
-            <div class="flex justify-end mt-4">
-                <button class="btn-secondary" @click="showPreview = false">Cerrar</button>
             </div>
         </div>
-    </div>
 
-    {{-- Modal: exportar y actualizar estado --}}
-    <div class="modal-overlay" x-show="showExport" x-cloak>
-        <div class="modal-box" style="max-width:640px;">
-            <h4 class="modal-title">
-                <i class="fas fa-file-download mr-2 text-indigo-500"></i>Exportar CSVs
-            </h4>
-            <p class="text-sm text-gray-600 mb-4">
-                Descarga los ficheros para
-                <strong x-text="selectedDocentes().length"></strong>
-                docente(s) seleccionado(s) y, cuando estés listo/a, cierra actualizando el estado.
-            </p>
+        {{-- Modal: exportar y actualizar estado --}}
+        <div class="modal" x-show="showExport" x-cloak>
+            <div class="modal-content" style="max-width:640px;">
+                <h4 class="modal-title">Exportar CSVs</h4>
+                <p class="modal-text">
+                    Descarga los ficheros para
+                    <strong x-text="selectedDocentes().length"></strong>
+                    docente(s) seleccionado(s) y, cuando estés listo/a, cierra actualizando el estado.
+                </p>
 
-            <div class="flex flex-wrap gap-3 mb-2">
-                <button class="btn-primary" @click="downloadCSV('google')">
-                    <i class="fab fa-google mr-1"></i>Descargar CSV Google Workspace
-                </button>
-                <button class="btn-primary" @click="downloadCSV('moodle')">
-                    <i class="fas fa-graduation-cap mr-1"></i>Descargar CSV Moodle
-                </button>
-            </div>
+                <div class="flex flex-wrap gap-3 mb-2">
+                    <button class="button button-primary" @click="downloadCSV('google')">
+                        <i class="fab fa-google mr-1"></i>Descargar CSV Google Workspace
+                    </button>
+                    <button class="button button-primary" @click="downloadCSV('moodle')">
+                        <i class="fas fa-graduation-cap mr-1"></i>Descargar CSV Moodle
+                    </button>
+                </div>
 
-            <hr class="divider">
+                <hr class="divider">
 
-            <div class="flex flex-wrap justify-between items-center gap-3">
-                <button class="btn-secondary" @click="cerrarSinActualizar()">
-                    <i class="fas fa-times mr-1"></i>Cerrar sin actualizar estado
-                </button>
-                <button class="btn-success"
-                        :disabled="procesando"
-                        :class="{ 'opacity-60 cursor-not-allowed': procesando }"
-                        @click="cerrarActualizando()">
-                    <span x-show="!procesando"><i class="fas fa-check-circle mr-1"></i>Cerrar y actualizar estado</span>
-                    <span x-show="procesando"><i class="fas fa-spinner fa-spin mr-1"></i>Actualizando…</span>
-                </button>
+                <div class="modal-actions">
+                    <button class="button button-secondary" @click="cerrarSinActualizar()">
+                        <i class="fas fa-times mr-1"></i>Cerrar sin actualizar estado
+                    </button>
+                    <button class="button button-success"
+                            :disabled="procesando"
+                            :class="{ 'opacity-60 cursor-not-allowed': procesando }"
+                            @click="cerrarActualizando()">
+                        <span x-show="!procesando"><i class="fas fa-check-circle mr-1"></i>Cerrar y actualizar estado</span>
+                        <span x-show="procesando"><i class="fas fa-spinner fa-spin mr-1"></i>Actualizando…</span>
+                    </button>
+                </div>
             </div>
         </div>
+
     </div>
 </div>
 
@@ -181,7 +168,6 @@ document.addEventListener('alpine:init', () => {
         procesando: false,
         docenteMap: @json($docentesJson),
 
-        // ── Estado reactivo ────────────────────────────────────────────
         getEstado(id) {
             return this.docenteMap.find(d => d.id === id)?.is_procesado ?? false;
         },
@@ -189,7 +175,6 @@ document.addEventListener('alpine:init', () => {
             return this.docenteMap.find(d => d.id === id)?.fecha_procesado ?? '—';
         },
 
-        // ── Selección ──────────────────────────────────────────────────
         toggleAll(event) {
             this.selected = event.target.checked ? this.docenteMap.map(d => String(d.id)) : [];
         },
@@ -212,108 +197,66 @@ document.addEventListener('alpine:init', () => {
             this.showExport = true;
         },
 
-        // ── Google Workspace CSV (29 columnas) ─────────────────────────
         csvLineGoogle(d) {
             const cols = [
-                d.nombre         || '',  //  1 First Name [Required]
-                d.apellido       || '',  //  2 Last Name [Required]
-                d.email_virtual  || '',  //  3 Email Address [Required]
-                'Cambiam3!_',            //  4 Password [Required]
-                '',                      //  5 Password Hash Function [UPLOAD ONLY]
-                '/Profesorado',          //  6 Org Unit Path [Required]
-                '',                      //  7 New Primary Email [UPLOAD ONLY]
-                d.email_personal || '',  //  8 Recovery Email
-                '',                      //  9 Home Secondary Email
-                d.email_personal || '',  // 10 Work Secondary Email
-                '',                      // 11 Recovery Phone
-                '',                      // 12 Work Phone
-                '',                      // 13 Home Phone
-                '',                      // 14 Mobile Phone
-                '',                      // 15 Work Address
-                '',                      // 16 Home Address
-                d.dni            || '',  // 17 Employee ID
-                '',                      // 18 Employee Type
-                '',                      // 19 Employee Title
-                '',                      // 20 Manager Email
-                '',                      // 21 Department
-                '',                      // 22 Cost Center
-                '',                      // 23 Building ID
-                '',                      // 24 Floor Name
-                '',                      // 25 Floor Section
-                'TRUE',                  // 26 Change Password at Next Sign-In
-                'Active',                // 27 New Status [UPLOAD ONLY]
-                '',                      // 28 New Licenses [UPLOAD ONLY]
-                'FALSE',                 // 29 Advanced Protection Program enrollment
+                d.nombre         || '',
+                d.apellido       || '',
+                d.email_virtual  || '',
+                'Cambiam3!_',
+                '',
+                '/Profesorado',
+                '',
+                d.email_personal || '',
+                '',
+                d.email_personal || '',
+                '', '', '', '', '', '',
+                d.dni            || '',
+                '', '', '', '', '', '', '', '',
+                'TRUE',
+                'Active',
+                '',
+                'FALSE',
             ];
             return cols.join(',');
         },
 
-        // ── Moodle CSV (29 columnas — sin Work Secondary Email ni New Status)
         csvLineMoodle(d) {
             const cols = [
-                d.nombre         || '',  //  1 First Name [Required]
-                d.apellido       || '',  //  2 Last Name [Required]
-                d.email_virtual  || '',  //  3 Email Address [Required]
-                'Cambiam3!_',            //  4 Password [Required]
-                '',                      //  5 Password Hash Function [UPLOAD ONLY]
-                '/Profesorado',          //  6 Org Unit Path [Required]
-                '',                      //  7 New Primary Email [UPLOAD ONLY]
-                d.email_personal || '',  //  8 Recovery Email
-                '',                      //  9 Home Secondary Email
-                '',                      // 10 Work Secondary Email
-                '',                      // 11 Recovery Phone
-                '',                      // 12 Work Phone
-                '',                      // 13 Home Phone
-                '',                      // 14 Mobile Phone
-                '',                      // 15 Work Address
-                '',                      // 16 Home Address
-                d.dni            || '',  // 17 Employee ID
-                '',                      // 18 Employee Type
-                '',                      // 19 Employee Title
-                '',                      // 20 Manager Email
-                '',                      // 21 Department
-                '',                      // 22 Cost Center
-                '',                      // 23 Building ID
-                '',                      // 24 Floor Name
-                '',                      // 25 Floor Section
-                'TRUE',                  // 26 Change Password at Next Sign-In
-                '',                      // 27 New Status [UPLOAD ONLY]
-                '',                      // 28 New Licenses [UPLOAD ONLY]
-                'FALSE',                 // 29 Advanced Protection Program enrollment
+                d.nombre         || '',
+                d.apellido       || '',
+                d.email_virtual  || '',
+                'Cambiam3!_',
+                '',
+                '/Profesorado',
+                '',
+                d.email_personal || '',
+                '',
+                '',
+                '', '', '', '', '', '',
+                d.dni            || '',
+                '', '', '', '', '', '', '', '',
+                'TRUE',
+                '',
+                '',
+                'FALSE',
             ];
             return cols.join(',');
         },
 
-        // ── Descarga ───────────────────────────────────────────────────
         downloadCSV(tipo) {
             const docs  = this.selectedDocentes();
             let   lines = [];
+            const header = 'First Name [Required],Last Name [Required],Email Address [Required],' +
+                'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],' +
+                'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,' +
+                'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,' +
+                'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,' +
+                'Department,Cost Center,Building ID,Floor Name,Floor Section,' +
+                'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],' +
+                'Advanced Protection Program enrollment';
 
-            if (tipo === 'google') {
-                lines.push(
-                    'First Name [Required],Last Name [Required],Email Address [Required],' +
-                    'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],' +
-                    'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,' +
-                    'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,' +
-                    'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,' +
-                    'Department,Cost Center,Building ID,Floor Name,Floor Section,' +
-                    'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],' +
-                    'Advanced Protection Program enrollment'
-                );
-                docs.forEach(d => lines.push(this.csvLineGoogle(d)));
-            } else {
-                lines.push(
-                    'First Name [Required],Last Name [Required],Email Address [Required],' +
-                    'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],' +
-                    'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,' +
-                    'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,' +
-                    'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,' +
-                    'Department,Cost Center,Building ID,Floor Name,Floor Section,' +
-                    'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],' +
-                    'Advanced Protection Program enrollment'
-                );
-                docs.forEach(d => lines.push(this.csvLineMoodle(d)));
-            }
+            lines.push(header);
+            docs.forEach(d => lines.push(tipo === 'google' ? this.csvLineGoogle(d) : this.csvLineMoodle(d)));
 
             const bom  = '﻿';
             const blob = new Blob([bom + lines.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
@@ -325,7 +268,6 @@ document.addEventListener('alpine:init', () => {
             URL.revokeObjectURL(url);
         },
 
-        // ── Cierre del modal ───────────────────────────────────────────
         cerrarSinActualizar() {
             this.showExport = false;
         },
@@ -333,8 +275,8 @@ document.addEventListener('alpine:init', () => {
         cerrarActualizando() {
             if (this.procesando) return;
             this.procesando = true;
-            const token       = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
-            const idsAmarcar  = [...this.selected];
+            const token      = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+            const idsAmarcar = [...this.selected];
 
             fetch('{{ route("admin.alta-plataforma.procesar") }}', {
                 method:  'POST',
@@ -348,7 +290,7 @@ document.addEventListener('alpine:init', () => {
                     hour: '2-digit', minute: '2-digit',
                 });
                 idsAmarcar.forEach(id => {
-                    const d = this.docenteMap.find(d => d.id === id);
+                    const d = this.docenteMap.find(d => d.id === Number(id));
                     if (d) { d.is_procesado = true; d.fecha_procesado = ahora; }
                 });
                 this.showExport = false;

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -255,7 +255,16 @@ document.addEventListener('alpine:init', () => {
                 );
                 docs.forEach(d => lines.push(this.csvLineGoogle(d)));
             } else {
-                lines.push('username,firstname,lastname,email');
+                lines.push(
+                    'First Name [Required],Last Name [Required],Email Address [Required],' +
+                    'Password [Required],Password Hash Function [UPLOAD ONLY],Org Unit Path [Required],' +
+                    'New Primary Email [UPLOAD ONLY],Recovery Email,Home Secondary Email,Work Secondary Email,' +
+                    'Recovery Phone [MUST BE IN THE E.164 FORMAT],Work Phone,Home Phone,Mobile Phone,' +
+                    'Work Address,Home Address,Employee ID,Employee Type,Employee Title,Manager Email,' +
+                    'Department,Cost Center,Building ID,Floor Name,Floor Section,' +
+                    'Change Password at Next Sign-In,New Status [UPLOAD ONLY],New Licenses [UPLOAD ONLY],' +
+                    'Advanced Protection Program enrollment'
+                );
                 docs.forEach(d => lines.push(this.csvLineMoodle(d)));
             }
 

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -214,27 +214,73 @@ document.addEventListener('alpine:init', () => {
         // ── Google Workspace CSV (29 columnas) ─────────────────────────
         csvLineGoogle(d) {
             const cols = [
-                d.nombre          || '',   //  1 First Name [Required]
-                d.apellido        || '',   //  2 Last Name [Required]
-                d.email_virtual   || '',   //  3 Email Address [Required]
-                'Cambiam3!_',              //  4 Password [Required]
-                '',                        //  5 Password Hash Function [UPLOAD ONLY]
-                '/Profesorado',            //  6 Org Unit Path [Required]
-                '',                        //  7 New Primary Email [UPLOAD ONLY]
-                d.email_personal  || '',   //  8 Recovery Email
-                '', '', '', '', '', '', '', '', //  9-16 vacías
-                d.dni             || '',   // 17 Employee ID
-                '', '', '', '', '', '', '', '', // 18-25 vacías
-                'TRUE',                    // 26 Change Password at Next Sign-In
-                '', '',                    // 27-28 New Status, New Licenses
-                'FALSE',                   // 29 Advanced Protection Program enrollment
+                d.nombre         || '',  //  1 First Name [Required]
+                d.apellido       || '',  //  2 Last Name [Required]
+                d.email_virtual  || '',  //  3 Email Address [Required]
+                'Cambiam3!_',            //  4 Password [Required]
+                '',                      //  5 Password Hash Function [UPLOAD ONLY]
+                '/Profesorado',          //  6 Org Unit Path [Required]
+                '',                      //  7 New Primary Email [UPLOAD ONLY]
+                d.email_personal || '',  //  8 Recovery Email
+                '',                      //  9 Home Secondary Email
+                d.email_personal || '',  // 10 Work Secondary Email
+                '',                      // 11 Recovery Phone
+                '',                      // 12 Work Phone
+                '',                      // 13 Home Phone
+                '',                      // 14 Mobile Phone
+                '',                      // 15 Work Address
+                '',                      // 16 Home Address
+                d.dni            || '',  // 17 Employee ID
+                '',                      // 18 Employee Type
+                '',                      // 19 Employee Title
+                '',                      // 20 Manager Email
+                '',                      // 21 Department
+                '',                      // 22 Cost Center
+                '',                      // 23 Building ID
+                '',                      // 24 Floor Name
+                '',                      // 25 Floor Section
+                'TRUE',                  // 26 Change Password at Next Sign-In
+                'Active',                // 27 New Status [UPLOAD ONLY]
+                '',                      // 28 New Licenses [UPLOAD ONLY]
+                'FALSE',                 // 29 Advanced Protection Program enrollment
             ];
             return cols.join(',');
         },
 
-        // ── Moodle CSV (29 columnas — mismo formato que Google Workspace) ─
+        // ── Moodle CSV (29 columnas — sin Work Secondary Email ni New Status)
         csvLineMoodle(d) {
-            return this.csvLineGoogle(d);
+            const cols = [
+                d.nombre         || '',  //  1 First Name [Required]
+                d.apellido       || '',  //  2 Last Name [Required]
+                d.email_virtual  || '',  //  3 Email Address [Required]
+                'Cambiam3!_',            //  4 Password [Required]
+                '',                      //  5 Password Hash Function [UPLOAD ONLY]
+                '/Profesorado',          //  6 Org Unit Path [Required]
+                '',                      //  7 New Primary Email [UPLOAD ONLY]
+                d.email_personal || '',  //  8 Recovery Email
+                '',                      //  9 Home Secondary Email
+                '',                      // 10 Work Secondary Email
+                '',                      // 11 Recovery Phone
+                '',                      // 12 Work Phone
+                '',                      // 13 Home Phone
+                '',                      // 14 Mobile Phone
+                '',                      // 15 Work Address
+                '',                      // 16 Home Address
+                d.dni            || '',  // 17 Employee ID
+                '',                      // 18 Employee Type
+                '',                      // 19 Employee Title
+                '',                      // 20 Manager Email
+                '',                      // 21 Department
+                '',                      // 22 Cost Center
+                '',                      // 23 Building ID
+                '',                      // 24 Floor Name
+                '',                      // 25 Floor Section
+                'TRUE',                  // 26 Change Password at Next Sign-In
+                '',                      // 27 New Status [UPLOAD ONLY]
+                '',                      // 28 New Licenses [UPLOAD ONLY]
+                'FALSE',                 // 29 Advanced Protection Program enrollment
+            ];
+            return cols.join(',');
         },
 
         // ── Descarga ───────────────────────────────────────────────────

--- a/resources/views/admin/alta_plataforma.blade.php
+++ b/resources/views/admin/alta_plataforma.blade.php
@@ -191,15 +191,16 @@ document.addEventListener('alpine:init', () => {
 
         // ── Selección ──────────────────────────────────────────────────
         toggleAll(event) {
-            this.selected = event.target.checked ? this.docenteMap.map(d => d.id) : [];
+            this.selected = event.target.checked ? this.docenteMap.map(d => String(d.id)) : [];
         },
         syncCheckAll() {
-            const allIds = this.docenteMap.map(d => d.id);
+            const allIds = this.docenteMap.map(d => String(d.id));
             this.$refs.checkAll.checked = allIds.length > 0 && allIds.every(id => this.selected.includes(id));
             this.$refs.checkAll.indeterminate = this.selected.length > 0 && !this.$refs.checkAll.checked;
         },
         selectedDocentes() {
-            return this.docenteMap.filter(d => this.selected.includes(d.id));
+            const nums = this.selected.map(Number);
+            return this.docenteMap.filter(d => nums.includes(d.id));
         },
 
         verDetalle(id) {

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -8,7 +8,7 @@
                 <div class="panel-header">
                     <h3 class="alta-title">Panel de Administración</h3>
                     <p class="alta-subtitle">
-                        Bienvenido {{ Auth::guard('admin')->user()->user }} aquí podrás gestionar la administración.
+                        Bienvenido {{ optional(Auth::guard('admin')->user())->user ?? optional(auth()->user())->nombre ?? 'Admin' }} aquí podrás gestionar la administración.
                     </p>
                 </div>
 

--- a/resources/views/admin/ver_docentes.blade.php
+++ b/resources/views/admin/ver_docentes.blade.php
@@ -13,6 +13,7 @@
             docenteInfo: {},
             isLoading: false,
             error: null,
+            togglingAdmin: false,
             loadDocenteInfo(docenteId) {
                 this.isLoading = true;
                 this.error = null;
@@ -40,6 +41,25 @@
                 .finally(() => {
                     this.isLoading = false;
                 });
+            },
+            toggleAdmin(dni) {
+                if (this.togglingAdmin) return;
+                this.togglingAdmin = true;
+                const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+                fetch(`/admin/docentes/${dni}/toggle-admin`, {
+                    method: 'POST',
+                    headers: { 'Accept': 'application/json', 'X-CSRF-TOKEN': token }
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.ok) {
+                        this.docenteInfo.usuario_is_admin = data.is_admin;
+                    } else {
+                        alert(data.error ?? 'Error al cambiar el rol.');
+                    }
+                })
+                .catch(() => alert('Error al cambiar el rol.'))
+                .finally(() => { this.togglingAdmin = false; });
             }
         }));
     });
@@ -183,7 +203,7 @@
                         this.showModal = true;
                         this.isLoading = true;
                         this.errorMessage = '';
-                        
+
                         fetch(`/admin/docentes/${dni}/info`, {
                             headers: {
                                 'Accept': 'application/json',

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -38,7 +38,7 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::guard('admin')->user()->user }}</div>
+                            <div>{{ optional(Auth::guard('admin')->user())->user ?? optional(auth()->user())->nombre ?? 'Admin' }}</div>
                             <div class="ms-1">
                                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -57,7 +57,7 @@
                         {{ __('Baja Docente') }}
                     </x-nav-link>
                 </div>
-                @if(auth()->check() && \App\Models\Admin::where('email', auth()->user()->email)->exists())
+                @if(auth()->check() && auth()->user()->is_admin)
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                     <x-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
                         {{ __('Alta Plataforma') }}
@@ -164,7 +164,7 @@
                 {{ __('Baja Docente') }}
             </x-responsive-nav-link>
         </div>
-        @if(auth()->check() && \App\Models\Admin::where('email', auth()->user()->email)->exists())
+        @if(auth()->check() && auth()->user()->is_admin)
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
                 {{ __('Alta Plataforma') }}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -57,6 +57,13 @@
                         {{ __('Baja Docente') }}
                     </x-nav-link>
                 </div>
+                @if(auth()->check() && \App\Models\Admin::where('email', auth()->user()->email)->exists())
+                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                    <x-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
+                        {{ __('Alta Plataforma') }}
+                    </x-nav-link>
+                </div>
+                @endif
             </div>
 
             <!-- Settings Dropdown -->
@@ -157,6 +164,13 @@
                 {{ __('Baja Docente') }}
             </x-responsive-nav-link>
         </div>
+        @if(auth()->check() && \App\Models\Admin::where('email', auth()->user()->email)->exists())
+        <div class="pt-2 pb-3 space-y-1">
+            <x-responsive-nav-link :href="route('admin.alta-plataforma')" :active="request()->routeIs('admin.alta-plataforma')">
+                {{ __('Alta Plataforma') }}
+            </x-responsive-nav-link>
+        </div>
+        @endif
         <!-- Responsive Settings Options -->
         <div class="pt-4 pb-1 border-t border-gray-200">
             <div class="mt-3 space-y-1">               

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,8 +88,11 @@ Route::middleware(['auth'])->group(function () {
 
 // Admin
 Route::middleware('web')->prefix('admin')->name('admin.')->group(function () {
-    // Ruta /admin que muestra login si no está logueado, o redirige al dashboard si está autenticado
+    // Ruta /admin que redirige al dashboard si está autenticado como admin, o al login
     Route::get('/', function () {
+        if (auth()->check() && \App\Models\Admin::where('email', auth()->user()->email)->exists()) {
+            return redirect()->route('admin.dashboard');
+        }
         if (auth('admin')->check()) {
             return redirect()->route('admin.dashboard');
         }
@@ -101,8 +104,8 @@ Route::middleware('web')->prefix('admin')->name('admin.')->group(function () {
     Route::post('login', [AdminLoginController::class, 'login'])->name('login.submit');
     Route::post('logout', [AdminLoginController::class, 'logout'])->name('logout');
 
-    // Rutas protegidas para admin
-    Route::middleware('auth:admin')->group(function () {
+    // Rutas protegidas para admin (accesibles con login web si el usuario es admin)
+    Route::middleware(['auth', 'es_admin'])->group(function () {
         Route::get('dashboard', function () {
             return view('admin.dashboard');
         })->name('dashboard');
@@ -122,7 +125,6 @@ Route::middleware('web')->prefix('admin')->name('admin.')->group(function () {
         Route::get('alta-plataforma/{id}/preview', [AltaPlataformaController::class, 'preview']);
         Route::post('alta-plataforma/procesar', [AltaPlataformaController::class, 'procesarAltas'])
             ->name('alta-plataforma.procesar');
-
     });
 });
 

--- a/tests/Feature/AltaPlataformaTest.php
+++ b/tests/Feature/AltaPlataformaTest.php
@@ -1,25 +1,22 @@
 <?php
 
 /**
- * Suite de tests — Issue #60: Vista para altas individuales/masivas del profesorado
- *
- * Cubre:
- *   A) Acceso y autenticación
- *   B) procesarAltas (POST /admin/alta-plataforma/procesar)
- *   C) Endpoint preview (GET /admin/alta-plataforma/{id}/preview)
- *   D) Filtros (estado, búsqueda)
+ * Suite de tests — Issue #60/#61/#62: Alta en Plataforma (Google Workspace / Moodle)
  *
  * Ejecución:
  *   ./vendor/bin/pest tests/Feature/AltaPlataformaTest.php --no-coverage
  */
 
 use App\Models\Admin;
+use App\Models\Centro;
+use App\Models\CentroDocente;
 use App\Models\Docente;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-// ── Helper ────────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
 function adminUser(): Admin
 {
     return Admin::forceCreate([
@@ -33,241 +30,309 @@ function docenteConEmail(array $extra = []): Docente
 {
     static $seq = 0;
     $seq++;
+    $dni = str_pad($seq, 8, '0', STR_PAD_LEFT) . 'T';
+
     return Docente::forceCreate(array_merge([
-        'nombre'        => 'Docente',
-        'apellido'      => 'Apellido',
-        'dni'           => str_pad($seq, 8, '0', STR_PAD_LEFT) . 'X',
-        'email_virtual' => "docente{$seq}@fpvirtualaragon.es",
+        'dni'           => $dni,
+        'nombre'        => 'Docente' . $seq,
+        'apellido'      => 'Apellido' . $seq,
+        'email_virtual' => 'docente' . $seq . '@fpvirtualaragon.es',
         'de_baja'       => false,
         'is_procesado'  => false,
+        'fecha_procesado' => null,
     ], $extra));
 }
 
+// ── BLOQUE A: Acceso y autenticación ──────────────────────────────────────────
 
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE A — Acceso y autenticación
-// ════════════════════════════════════════════════════════════════════════════
-
-test('A1 · un invitado es redirigido a admin/login al acceder a alta-plataforma', function () {
-    $response = $this->get('/admin/alta-plataforma');
-    $response->assertRedirect(route('admin.login'));
+test('A1 · usuario no autenticado es redirigido al login de admin', function () {
+    $this->get('/admin/alta-plataforma')
+         ->assertRedirect('/admin/login');
 });
 
-test('A2 · un usuario normal (guard web) es redirigido a admin/login', function () {
-    $centro  = \App\Models\Centro::forceCreate(['id_centro' => 'CA01', 'nombre' => 'Centro A']);
-    $usuario = \App\Models\Usuario::factory()->create(['id_centro' => 'CA01']);
+test('A2 · usuario normal (guard web) no puede acceder a la vista de admin', function () {
+    $centro  = Centro::forceCreate(['id_centro' => 'AP01', 'nombre' => 'Centro AP Test']);
+    $usuario = \App\Models\Usuario::factory()->create(['id_centro' => 'AP01']);
 
-    $response = $this->actingAs($usuario)->get('/admin/alta-plataforma');
-    $response->assertRedirect(route('admin.login'));
+    $this->actingAs($usuario, 'web')
+         ->get('/admin/alta-plataforma')
+         ->assertRedirect('/admin/login');
 });
 
-test('A3 · un admin autenticado puede acceder a la página', function () {
-    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
-    $response->assertStatus(200);
+test('A3 · admin autenticado puede acceder a la vista de alta plataforma', function () {
+    $admin = adminUser();
+
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma')
+         ->assertStatus(200);
 });
 
-test('A4 · la página contiene el título esperado', function () {
-    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
-    $response->assertSee('Alta en Plataforma');
+test('A4 · la vista muestra docentes con email_virtual asignado', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail(['nombre' => 'Alicia', 'apellido' => 'Constante Lanuza']);
+
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma')
+         ->assertStatus(200)
+         ->assertSee('Alicia')
+         ->assertSee('Constante Lanuza');
 });
 
-test('A5 · la página muestra los docentes activos con email_virtual', function () {
-    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Herrera']);
-    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Montes']);
+test('A5 · la vista NO muestra docentes dados de baja', function () {
+    $admin        = adminUser();
+    $bajado       = docenteConEmail(['nombre' => 'BajadoTest', 'de_baja' => true]);
+    $activo       = docenteConEmail(['nombre' => 'ActivoTest',  'de_baja' => false]);
 
-    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
-    $response->assertSee('Guillermo');
-    $response->assertSee('Valentina');
+    $response = $this->actingAs($admin, 'admin')
+                     ->get('/admin/alta-plataforma');
+
+    $response->assertStatus(200)
+             ->assertSee('ActivoTest')
+             ->assertDontSee('BajadoTest');
 });
 
-test('A6 · la página NO muestra docentes de baja', function () {
-    docenteConEmail(['nombre' => 'BajaDocente', 'apellido' => 'Oculto', 'de_baja' => true]);
+test('A6 · filtro estado=pendiente muestra solo docentes no procesados', function () {
+    $admin     = adminUser();
+    $pendiente = docenteConEmail(['nombre' => 'SoloPendienteXYZ', 'is_procesado' => false]);
+    $procesado = docenteConEmail(['nombre' => 'SoloProcesadoXYZ', 'is_procesado' => true, 'fecha_procesado' => now()]);
 
-    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
-    $response->assertDontSee('BajaDocente');
+    $response = $this->actingAs($admin, 'admin')
+                     ->get('/admin/alta-plataforma?estado=pendiente');
+
+    $response->assertStatus(200)
+             ->assertSee('SoloPendienteXYZ')
+             ->assertDontSee('SoloProcesadoXYZ');
 });
 
-test('A7 · la página NO muestra docentes sin email_virtual', function () {
-    Docente::forceCreate([
-        'nombre'        => 'SinEmail',
-        'apellido'      => 'Virtual',
-        'dni'           => '99999901S',
-        'email_virtual' => '',
-        'de_baja'       => false,
-    ]);
+test('A7 · filtro estado=procesado muestra solo docentes ya procesados', function () {
+    $admin     = adminUser();
+    $pendiente = docenteConEmail(['nombre' => 'Pendiente2', 'is_procesado' => false]);
+    $procesado = docenteConEmail(['nombre' => 'Procesado2', 'is_procesado' => true, 'fecha_procesado' => now()]);
 
-    $response = $this->actingAs(adminUser(), 'admin')->get('/admin/alta-plataforma');
-    $response->assertDontSee('SinEmail');
+    $response = $this->actingAs($admin, 'admin')
+                     ->get('/admin/alta-plataforma?estado=procesado');
+
+    $response->assertStatus(200)
+             ->assertSee('Procesado2')
+             ->assertDontSee('Pendiente2');
 });
 
+// ── BLOQUE B: procesarAltas ────────────────────────────────────────────────────
 
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE B — procesarAltas
-// ════════════════════════════════════════════════════════════════════════════
-
-test('B1 · procesar un docente lo marca como is_procesado=true', function () {
+test('B1 · POST sin autenticación devuelve redirección', function () {
     $docente = docenteConEmail();
 
-    $this->actingAs(adminUser(), 'admin')
+    $this->post('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]])
+         ->assertRedirect();
+});
+
+test('B2 · procesarAltas marca is_procesado=true y guarda fecha_procesado', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail(['is_procesado' => false]);
+
+    $this->actingAs($admin, 'admin')
          ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]])
          ->assertStatus(200)
          ->assertJson(['ok' => true]);
 
-    expect($docente->fresh()->is_procesado)->toBeTrue();
+    $this->assertDatabaseHas('docentes', [
+        'id'           => $docente->id,
+        'is_procesado' => true,
+    ]);
+
+    $docente->refresh();
+    expect($docente->fecha_procesado)->not->toBeNull();
 });
 
-test('B2 · procesar un docente guarda la fecha_procesado', function () {
-    $docente = docenteConEmail();
+test('B3 · procesarAltas no modifica docentes de baja', function () {
+    $admin  = adminUser();
+    $bajado = docenteConEmail(['de_baja' => true, 'is_procesado' => false]);
 
-    $this->actingAs(adminUser(), 'admin')
-         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]]);
+    $this->actingAs($admin, 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$bajado->id]])
+         ->assertStatus(200);
 
-    expect($docente->fresh()->fecha_procesado)->not->toBeNull();
+    $this->assertDatabaseHas('docentes', [
+        'id'           => $bajado->id,
+        'is_procesado' => false,
+    ]);
 });
 
-test('B3 · procesar varios docentes a la vez actualiza todos', function () {
-    $d1 = docenteConEmail();
-    $d2 = docenteConEmail();
+test('B4 · procesarAltas valida que ids sea requerido', function () {
+    $admin = adminUser();
 
-    $this->actingAs(adminUser(), 'admin')
-         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$d1->id, $d2->id]])
-         ->assertJson(['ok' => true, 'procesados' => 2]);
-
-    expect($d1->fresh()->is_procesado)->toBeTrue();
-    expect($d2->fresh()->is_procesado)->toBeTrue();
-});
-
-test('B4 · procesar sin ids devuelve error de validación', function () {
-    $this->actingAs(adminUser(), 'admin')
+    $this->actingAs($admin, 'admin')
          ->postJson('/admin/alta-plataforma/procesar', [])
-         ->assertStatus(422);
+         ->assertStatus(422)
+         ->assertJsonValidationErrors(['ids']);
 });
 
-test('B5 · procesar con ids vacíos devuelve error de validación', function () {
-    $this->actingAs(adminUser(), 'admin')
-         ->postJson('/admin/alta-plataforma/procesar', ['ids' => []])
-         ->assertStatus(422);
+test('B5 · procesarAltas valida que ids sea un array', function () {
+    $admin = adminUser();
+
+    $this->actingAs($admin, 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => 'no-es-array'])
+         ->assertStatus(422)
+         ->assertJsonValidationErrors(['ids']);
 });
 
-test('B6 · un docente de baja no se marca como procesado aunque esté en los ids', function () {
-    $docente = docenteConEmail(['de_baja' => true, 'is_procesado' => false]);
+test('B6 · procesarAltas valida que los ids existen en la tabla docentes', function () {
+    $admin = adminUser();
 
-    $this->actingAs(adminUser(), 'admin')
-         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]]);
-
-    expect($docente->fresh()->is_procesado)->toBeFalse();
+    $this->actingAs($admin, 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [99999]])
+         ->assertStatus(422)
+         ->assertJsonValidationErrors(['ids.0']);
 });
 
-test('B7 · un invitado no puede llamar a procesarAltas', function () {
+test('B7 · procesarAltas devuelve JSON con ok=true y el número de procesados', function () {
+    $admin = adminUser();
+    $d1    = docenteConEmail();
+    $d2    = docenteConEmail();
+
+    $this->actingAs($admin, 'admin')
+         ->postJson('/admin/alta-plataforma/procesar', ['ids' => [$d1->id, $d2->id]])
+         ->assertStatus(200)
+         ->assertJson(['ok' => true, 'procesados' => 2]);
+});
+
+// ── BLOQUE C: preview ─────────────────────────────────────────────────────────
+
+test('C1 · preview devuelve JSON con todos los campos esperados', function () {
+    $admin   = adminUser();
     $docente = docenteConEmail();
 
-    $this->postJson('/admin/alta-plataforma/procesar', ['ids' => [$docente->id]])
-         ->assertStatus(302); // redirige al login
-});
-
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE C — Endpoint preview
-// ════════════════════════════════════════════════════════════════════════════
-
-test('C1 · el endpoint preview devuelve el dni del docente', function () {
-    $docente = docenteConEmail(['dni' => '12345678C']);
-
-    $this->actingAs(adminUser(), 'admin')
+    $this->actingAs($admin, 'admin')
          ->getJson("/admin/alta-plataforma/{$docente->id}/preview")
          ->assertStatus(200)
-         ->assertJsonPath('dni', '12345678C');
+         ->assertJsonStructure([
+             'dni', 'nombre', 'apellido', 'email_virtual', 'email_personal',
+             'google_csv', 'moodle_csv', 'google_header', 'moodle_header',
+         ]);
 });
 
-test('C2 · el endpoint preview devuelve el email_virtual', function () {
-    $docente = docenteConEmail(['email_virtual' => 'preview@fpvirtualaragon.es']);
+test('C2 · google_csv tiene exactamente 29 columnas', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
 
-    $this->actingAs(adminUser(), 'admin')
-         ->getJson("/admin/alta-plataforma/{$docente->id}/preview")
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $googleCsv = $response->json('google_csv');
+    $cols      = str_getcsv($googleCsv);
+    expect(count($cols))->toBe(29);
+});
+
+test('C3 · google_csv contiene la contraseña y la unidad organizativa correctas', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $cols = str_getcsv($response->json('google_csv'));
+
+    expect($cols[3])->toBe('Cambiam3!_')   // col 4: Password
+         ->and($cols[5])->toBe('/Profesorado'); // col 6: Org Unit Path
+});
+
+test('C4 · el email_personal aparece en la columna Recovery Email (posición 8)', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
+    $centro  = Centro::forceCreate(['id_centro' => 'CP01', 'nombre' => 'Centro Preview']);
+    CentroDocente::forceCreate([
+        'dni'       => $docente->dni,
+        'id_centro' => 'CP01',
+        'email'     => 'personal@example.com',
+    ]);
+
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $cols = str_getcsv($response->json('google_csv'));
+
+    expect($cols[7])->toBe('personal@example.com'); // col 8 (index 7)
+});
+
+test('C5 · moodle_csv tiene formato: "profDNI","nombre","apellido","email_virtual"', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $moodleCsv = $response->json('moodle_csv');
+
+    expect($moodleCsv)->toStartWith('"prof' . $docente->dni . '"');
+
+    $cols = str_getcsv($moodleCsv);
+    expect(count($cols))->toBe(4);
+});
+
+test('C6 · google_header tiene exactamente 29 nombres de columna', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $header = $response->json('google_header');
+    $cols   = str_getcsv($header);
+
+    expect(count($cols))->toBe(29)
+         ->and($cols[0])->toBe('First Name [Required]')
+         ->and($cols[2])->toBe('Email Address [Required]')
+         ->and($cols[28])->toBe('Advanced Protection Program enrollment');
+});
+
+// ── BLOQUE D: Filtros ─────────────────────────────────────────────────────────
+
+test('D1 · búsqueda por nombre muestra solo los docentes que coinciden', function () {
+    $admin     = adminUser();
+    $encontrar = docenteConEmail(['nombre' => 'UnicoNombre']);
+    $otro      = docenteConEmail(['nombre' => 'OtroNombre']);
+
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma?buscar=UnicoNombre')
          ->assertStatus(200)
-         ->assertJsonPath('email_virtual', 'preview@fpvirtualaragon.es');
+         ->assertSee('UnicoNombre')
+         ->assertDontSee('OtroNombre');
 });
 
-test('C3 · el endpoint preview incluye la línea google_csv', function () {
-    $docente = docenteConEmail();
+test('D2 · búsqueda por apellido muestra solo los docentes que coinciden', function () {
+    $admin     = adminUser();
+    $encontrar = docenteConEmail(['apellido' => 'UnicoApellido']);
+    $otro      = docenteConEmail(['apellido' => 'OtroApellido']);
 
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
-
-    $response->assertStatus(200);
-    expect($response->json('google_csv'))->toBeString()->not->toBeEmpty();
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma?buscar=UnicoApellido')
+         ->assertStatus(200)
+         ->assertSee('UnicoApellido')
+         ->assertDontSee('OtroApellido');
 });
 
-test('C4 · el endpoint preview incluye la línea moodle_csv', function () {
-    $docente = docenteConEmail();
+test('D3 · búsqueda por DNI muestra solo el docente que coincide', function () {
+    $admin     = adminUser();
+    $encontrar = docenteConEmail(['dni' => '99887766X']);
+    $otro      = docenteConEmail(['dni' => '11223344Y']);
 
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
-
-    $response->assertStatus(200);
-    expect($response->json('moodle_csv'))->toBeString()->not->toBeEmpty();
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma?buscar=99887766X')
+         ->assertStatus(200)
+         ->assertSee('99887766X')
+         ->assertDontSee('11223344Y');
 });
 
-test('C5 · la línea moodle_csv empieza con "prof" seguido del DNI', function () {
-    $docente = docenteConEmail(['dni' => '87654321M']);
+test('D4 · sin filtros se muestran todos los docentes activos con email_virtual', function () {
+    $admin = adminUser();
+    $d1    = docenteConEmail(['nombre' => 'Primero']);
+    $d2    = docenteConEmail(['nombre' => 'Segundo']);
+    $d3    = docenteConEmail(['nombre' => 'Tercero']);
 
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
-
-    expect($response->json('moodle_csv'))->toStartWith('"prof87654321M"');
-});
-
-test('C6 · el endpoint preview devuelve 404 para un id inexistente', function () {
-    $this->actingAs(adminUser(), 'admin')
-         ->getJson('/admin/alta-plataforma/9999/preview')
-         ->assertStatus(404);
-});
-
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE D — Filtros
-// ════════════════════════════════════════════════════════════════════════════
-
-test('D1 · el filtro estado=pendiente solo muestra docentes no procesados', function () {
-    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Sin Procesar', 'is_procesado' => false]);
-    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Ya Procesada', 'is_procesado' => true]);
-
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->get('/admin/alta-plataforma?estado=pendiente');
-
-    $response->assertSee('Guillermo');
-    $response->assertDontSee('Valentina');
-});
-
-test('D2 · el filtro estado=procesado solo muestra docentes procesados', function () {
-    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Sin Procesar', 'is_procesado' => false]);
-    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Ya Procesada', 'is_procesado' => true]);
-
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->get('/admin/alta-plataforma?estado=procesado');
-
-    $response->assertSee('Valentina');
-    $response->assertDontSee('Guillermo');
-});
-
-test('D3 · la búsqueda por nombre filtra correctamente', function () {
-    docenteConEmail(['nombre' => 'Guillermo', 'apellido' => 'Herrera']);
-    docenteConEmail(['nombre' => 'Valentina', 'apellido' => 'Montes']);
-
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->get('/admin/alta-plataforma?buscar=Guillermo');
-
-    $response->assertSee('Guillermo');
-    $response->assertDontSee('Valentina');
-});
-
-test('D4 · la búsqueda por DNI filtra correctamente', function () {
-    docenteConEmail(['dni' => 'A1111111Z', 'nombre' => 'Guillermo', 'apellido' => 'Herrera']);
-    docenteConEmail(['dni' => 'B2222222Z', 'nombre' => 'Valentina', 'apellido' => 'Montes']);
-
-    $response = $this->actingAs(adminUser(), 'admin')
-         ->get('/admin/alta-plataforma?buscar=A1111111Z');
-
-    $response->assertSee('Guillermo');
-    $response->assertDontSee('Valentina');
+    $this->actingAs($admin, 'admin')
+         ->get('/admin/alta-plataforma')
+         ->assertStatus(200)
+         ->assertSee('Primero')
+         ->assertSee('Segundo')
+         ->assertSee('Tercero');
 });

--- a/tests/Feature/AltaPlataformaTest.php
+++ b/tests/Feature/AltaPlataformaTest.php
@@ -254,7 +254,7 @@ test('C4 · el email_personal aparece en la columna Recovery Email (posición 8)
     expect($cols[7])->toBe('personal@example.com'); // col 8 (index 7)
 });
 
-test('C5 · moodle_csv tiene formato: "profDNI","nombre","apellido","email_virtual"', function () {
+test('C5 · moodle_csv tiene exactamente 29 columnas (mismo formato que Google Workspace)', function () {
     $admin   = adminUser();
     $docente = docenteConEmail();
 
@@ -262,11 +262,24 @@ test('C5 · moodle_csv tiene formato: "profDNI","nombre","apellido","email_virtu
                      ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
 
     $moodleCsv = $response->json('moodle_csv');
+    $cols      = str_getcsv($moodleCsv);
 
-    expect($moodleCsv)->toStartWith('"prof' . $docente->dni . '"');
+    expect(count($cols))->toBe(29);
+});
 
-    $cols = str_getcsv($moodleCsv);
-    expect(count($cols))->toBe(4);
+test('C7 · moodle_header tiene exactamente 29 nombres de columna', function () {
+    $admin   = adminUser();
+    $docente = docenteConEmail();
+
+    $response = $this->actingAs($admin, 'admin')
+                     ->getJson("/admin/alta-plataforma/{$docente->id}/preview");
+
+    $header = $response->json('moodle_header');
+    $cols   = str_getcsv($header);
+
+    expect(count($cols))->toBe(29)
+         ->and($cols[0])->toBe('First Name [Required]')
+         ->and($cols[28])->toBe('Advanced Protection Program enrollment');
 });
 
 test('C6 · google_header tiene exactamente 29 nombres de columna', function () {

--- a/tests/Feature/AltaPlataformaTest.php
+++ b/tests/Feature/AltaPlataformaTest.php
@@ -236,7 +236,7 @@ test('C3 · google_csv contiene la contraseña y la unidad organizativa correcta
          ->and($cols[5])->toBe('/Profesorado'); // col 6: Org Unit Path
 });
 
-test('C4 · el email_personal aparece en la columna Recovery Email (posición 8)', function () {
+test('C4 · el email_personal aparece en Recovery Email (col 8) y Work Secondary Email (col 10) del google_csv', function () {
     $admin   = adminUser();
     $docente = docenteConEmail();
     $centro  = Centro::forceCreate(['id_centro' => 'CP01', 'nombre' => 'Centro Preview']);
@@ -251,7 +251,9 @@ test('C4 · el email_personal aparece en la columna Recovery Email (posición 8)
 
     $cols = str_getcsv($response->json('google_csv'));
 
-    expect($cols[7])->toBe('personal@example.com'); // col 8 (index 7)
+    expect($cols[7])->toBe('personal@example.com')   // col 8 Recovery Email
+         ->and($cols[9])->toBe('personal@example.com') // col 10 Work Secondary Email
+         ->and($cols[26])->toBe('Active');              // col 27 New Status
 });
 
 test('C5 · moodle_csv tiene exactamente 29 columnas (mismo formato que Google Workspace)', function () {

--- a/tests/Feature/GeneradorEmailVirtualTest.php
+++ b/tests/Feature/GeneradorEmailVirtualTest.php
@@ -3,12 +3,6 @@
 /**
  * Suite de tests — Issue #58: Generación de correo @fpvirtualaragon.es
  *
- * Cubre:
- *   A) Algoritmo del servicio GeneradorEmailVirtualService
- *   B) Integración con alta de docentes (AltaDocenteController@store)
- *   C) Endpoint AJAX previewEmail
- *   D) Colisiones y casos límite
- *
  * Ejecución:
  *   ./vendor/bin/pest tests/Feature/GeneradorEmailVirtualTest.php --no-coverage
  */
@@ -21,55 +15,43 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-// ── Helper ───────────────────────────────────────────────────────────────────
 function servicio(): GeneradorEmailVirtualService
 {
     return new GeneradorEmailVirtualService();
 }
 
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE A — Algoritmo del servicio
-// ════════════════════════════════════════════════════════════════════════════
+// ── BLOQUE A: Algoritmo ───────────────────────────────────────────────────────
 
 test('A1 · genera el email correcto para el ejemplo de la tabla (Dario Axel Ureña Garcia)', function () {
-    $email = servicio()->previsualizarEmail('Dario Axel', 'Ureña Garcia');
-    expect($email)->toBe('daurenag@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Dario Axel', 'Ureña Garcia'))->toBe('daurenag@fpvirtualaragon.es');
 });
 
 test('A2 · genera el email correcto para el ejemplo de la tabla (María Del Carmen Mónica Royo Lupón)', function () {
-    $email = servicio()->previsualizarEmail('María Del Carmen Mónica', 'Royo Lupón');
-    expect($email)->toBe('mdcmroyol@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('María Del Carmen Mónica', 'Royo Lupón'))->toBe('mdcmroyol@fpvirtualaragon.es');
 });
 
 test('A3 · docente con un solo nombre y dos apellidos', function () {
-    $email = servicio()->previsualizarEmail('Ana', 'García López');
-    expect($email)->toBe('agarcial@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Ana', 'García López'))->toBe('agarcial@fpvirtualaragon.es');
 });
 
 test('A4 · docente con un solo apellido (sin segundo apellido)', function () {
-    $email = servicio()->previsualizarEmail('Juan', 'García');
-    expect($email)->toBe('jgarcia@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Juan', 'García'))->toBe('jgarcia@fpvirtualaragon.es');
 });
 
 test('A5 · los acentos se eliminan en la parte local del email', function () {
-    $email = servicio()->previsualizarEmail('Óscar', 'Pérez Ávila');
-    expect($email)->toBe('opereza@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Óscar', 'Pérez Ávila'))->toBe('opereza@fpvirtualaragon.es');
 });
 
 test('A6 · la ñ se convierte en n', function () {
-    $email = servicio()->previsualizarEmail('Pedro', 'Muñoz Niño');
-    expect($email)->toBe('pmunozn@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Pedro', 'Muñoz Niño'))->toBe('pmunozn@fpvirtualaragon.es');
 });
 
 test('A7 · nombres con múltiples palabras generan todas sus iniciales', function () {
-    $email = servicio()->previsualizarEmail('José Luis María', 'Sánchez Torres');
-    expect($email)->toBe('jlmsanchezt@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('José Luis María', 'Sánchez Torres'))->toBe('jlmsanchezt@fpvirtualaragon.es');
 });
 
 test('A8 · el email generado usa siempre el dominio fpvirtualaragon.es', function () {
-    $email = servicio()->previsualizarEmail('Test', 'Apellido');
-    expect($email)->toEndWith('@fpvirtualaragon.es');
+    expect(servicio()->previsualizarEmail('Test', 'Apellido'))->toEndWith('@fpvirtualaragon.es');
 });
 
 test('A9 · el email generado está completamente en minúsculas', function () {
@@ -78,15 +60,11 @@ test('A9 · el email generado está completamente en minúsculas', function () {
 });
 
 test('A10 · no contiene caracteres no ASCII en la parte local', function () {
-    $email = servicio()->previsualizarEmail('Ángel', 'Martínez Cañón');
-    $localPart = explode('@', $email)[0];
+    $localPart = explode('@', servicio()->previsualizarEmail('Ángel', 'Martínez Cañón'))[0];
     expect($localPart)->toMatch('/^[a-z0-9]+$/');
 });
 
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE B — Integración con alta de docentes
-// ════════════════════════════════════════════════════════════════════════════
+// ── BLOQUE B: Integración con alta de docentes ────────────────────────────────
 
 test('B1 · al dar de alta un docente nuevo se genera automáticamente el email_virtual', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C001', 'nombre' => 'Centro Test']);
@@ -117,8 +95,7 @@ test('B2 · el email_virtual termina en @fpvirtualaragon.es al dar de alta', fun
         'id_centro' => 'C002',
     ]);
 
-    $docente = Docente::where('dni', '87654321C')->first();
-    expect($docente->email_virtual)->toEndWith('@fpvirtualaragon.es');
+    expect(Docente::where('dni', '87654321C')->first()->email_virtual)->toEndWith('@fpvirtualaragon.es');
 });
 
 test('B3 · el email personal del docente se guarda en centro_docente, no en email_virtual', function () {
@@ -134,22 +111,15 @@ test('B3 · el email personal del docente se guarda en centro_docente, no en ema
     ]);
 
     $docente = Docente::where('dni', '11223344E')->first();
-    // email_virtual NO es el email personal
     expect($docente->email_virtual)->not->toBe('elena.personal@centro.com');
     expect($docente->email_virtual)->toEndWith('@fpvirtualaragon.es');
-
-    // El email personal sí está en centro_docente
-    $this->assertDatabaseHas('centro_docente', [
-        'dni'   => '11223344E',
-        'email' => 'elena.personal@centro.com',
-    ]);
+    $this->assertDatabaseHas('centro_docente', ['dni' => '11223344E', 'email' => 'elena.personal@centro.com']);
 });
 
 test('B4 · si el docente ya existe en BD se respeta su email_virtual original', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C004', 'nombre' => 'Centro Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'C004']);
 
-    // Crear docente con email_virtual ya asignado
     Docente::forceCreate([
         'nombre'        => 'Pedro',
         'apellido'      => 'López García',
@@ -158,8 +128,6 @@ test('B4 · si el docente ya existe en BD se respeta su email_virtual original',
         'de_baja'       => false,
     ]);
 
-    // Dar de alta en otro centro
-    $centro2 = Centro::forceCreate(['id_centro' => 'C005', 'nombre' => 'Centro 2']);
     $this->actingAs($usuario)->post('/alta-docente', [
         'nombre'    => 'Pedro',
         'apellido'  => 'López García',
@@ -168,101 +136,61 @@ test('B4 · si el docente ya existe en BD se respeta su email_virtual original',
         'id_centro' => 'C004',
     ]);
 
-    // El email_virtual original NO se modifica
-    $docente = Docente::where('dni', '99887766P')->first();
-    expect($docente->email_virtual)->toBe('plopezg@fpvirtualaragon.es');
+    expect(Docente::where('dni', '99887766P')->first()->email_virtual)->toBe('plopezg@fpvirtualaragon.es');
 });
 
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE C — Endpoint AJAX previewEmail
-// ════════════════════════════════════════════════════════════════════════════
+// ── BLOQUE C: Endpoint AJAX previewEmail ─────────────────────────────────────
 
 test('C1 · el endpoint preview-email devuelve el email generado para nombre y apellido', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C010', 'nombre' => 'Centro Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'C010']);
 
-    $response = $this->actingAs($usuario)
-        ->getJson('/alta-docente/preview-email?nombre=Marta&apellido=Torres Ruiz');
-
-    $response->assertStatus(200)
-             ->assertJson(['email' => 'mtorresr@fpvirtualaragon.es']);
+    $this->actingAs($usuario)->getJson('/alta-docente/preview-email?nombre=Marta&apellido=Torres Ruiz')
+         ->assertStatus(200)
+         ->assertJson(['email' => 'mtorresr@fpvirtualaragon.es']);
 });
 
 test('C2 · el endpoint preview-email devuelve null si falta el nombre', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C011', 'nombre' => 'Centro Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'C011']);
 
-    $response = $this->actingAs($usuario)
-        ->getJson('/alta-docente/preview-email?apellido=Torres');
-
-    $response->assertStatus(200)
-             ->assertJson(['email' => null]);
+    $this->actingAs($usuario)->getJson('/alta-docente/preview-email?apellido=Torres')
+         ->assertStatus(200)->assertJson(['email' => null]);
 });
 
 test('C3 · el endpoint preview-email devuelve null si falta el apellido', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C012', 'nombre' => 'Centro Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'C012']);
 
-    $response = $this->actingAs($usuario)
-        ->getJson('/alta-docente/preview-email?nombre=Marta');
-
-    $response->assertStatus(200)
-             ->assertJson(['email' => null]);
+    $this->actingAs($usuario)->getJson('/alta-docente/preview-email?nombre=Marta')
+         ->assertStatus(200)->assertJson(['email' => null]);
 });
 
-
-// ════════════════════════════════════════════════════════════════════════════
-// BLOQUE D — Colisiones y casos límite
-// ════════════════════════════════════════════════════════════════════════════
+// ── BLOQUE D: Colisiones ──────────────────────────────────────────────────────
 
 test('D1 · si el email generado ya existe se añade sufijo numérico', function () {
-    // Crear docente que "ocupa" el email base
-    Docente::forceCreate([
-        'nombre'        => 'Ana',
-        'apellido'      => 'García López',
-        'dni'           => '11111111A',
-        'email_virtual' => 'agarcial@fpvirtualaragon.es',
-    ]);
-
-    $email = servicio()->generarOObtenerExistente('Ana', 'García López');
-    expect($email)->toBe('agarcial2@fpvirtualaragon.es');
+    Docente::forceCreate(['nombre' => 'Ana', 'apellido' => 'García López', 'dni' => '11111111A', 'email_virtual' => 'agarcial@fpvirtualaragon.es']);
+    expect(servicio()->generarOObtenerExistente('Ana', 'García López'))->toBe('agarcial2@fpvirtualaragon.es');
 });
 
 test('D2 · si el email con sufijo 2 también existe prueba con 3', function () {
-    Docente::forceCreate(['nombre'=>'A','apellido'=>'B','dni'=>'11111111X','email_virtual'=>'ab@fpvirtualaragon.es']);
-    Docente::forceCreate(['nombre'=>'A','apellido'=>'B','dni'=>'22222222X','email_virtual'=>'ab2@fpvirtualaragon.es']);
-
-    $email = servicio()->generarOObtenerExistente('A', 'B');
-    expect($email)->toBe('ab3@fpvirtualaragon.es');
+    Docente::forceCreate(['nombre' => 'A', 'apellido' => 'B', 'dni' => '11111111X', 'email_virtual' => 'ab@fpvirtualaragon.es']);
+    Docente::forceCreate(['nombre' => 'A', 'apellido' => 'B', 'dni' => '22222222X', 'email_virtual' => 'ab2@fpvirtualaragon.es']);
+    expect(servicio()->generarOObtenerExistente('A', 'B'))->toBe('ab3@fpvirtualaragon.es');
 });
 
 test('D3 · generarOObtenerExistente devuelve el email_virtual existente si el docente ya está en BD', function () {
-    Docente::forceCreate([
-        'nombre'        => 'Luis',
-        'apellido'      => 'Pérez Sanz',
-        'dni'           => '55555555L',
-        'email_virtual' => 'lperezs@fpvirtualaragon.es',
-    ]);
-
-    $email = servicio()->generarOObtenerExistente('Luis', 'Pérez Sanz', '55555555L');
-    expect($email)->toBe('lperezs@fpvirtualaragon.es');
+    Docente::forceCreate(['nombre' => 'Luis', 'apellido' => 'Pérez Sanz', 'dni' => '55555555L', 'email_virtual' => 'lperezs@fpvirtualaragon.es']);
+    expect(servicio()->generarOObtenerExistente('Luis', 'Pérez Sanz', '55555555L'))->toBe('lperezs@fpvirtualaragon.es');
 });
 
 test('D4 · comprobarDocente devuelve el email_virtual del docente existente', function () {
     $centro  = Centro::forceCreate(['id_centro' => 'C020', 'nombre' => 'Centro Test']);
     $usuario = Usuario::factory()->create(['id_centro' => 'C020']);
 
-    Docente::forceCreate([
-        'nombre'        => 'Rosa',
-        'apellido'      => 'Fernández',
-        'dni'           => '66666666R',
-        'email_virtual' => 'rfernandez@fpvirtualaragon.es',
-    ]);
+    Docente::forceCreate(['nombre' => 'Rosa', 'apellido' => 'Fernández', 'dni' => '66666666R', 'email_virtual' => 'rfernandez@fpvirtualaragon.es']);
 
-    $response = $this->actingAs($usuario)
-        ->getJson('/comprobar-docente/66666666R');
-
-    $response->assertStatus(200)
-             ->assertJsonPath('email_virtual', 'rfernandez@fpvirtualaragon.es');
+    $this->actingAs($usuario)->getJson('/comprobar-docente/66666666R')
+         ->assertStatus(200)
+         ->assertJsonPath('email_virtual', 'rfernandez@fpvirtualaragon.es');
 });


### PR DESCRIPTION
## Descripción

Implementa la generación de los ficheros CSV necesarios para dar de alta 
al profesorado en Google Workspace y Moodle, cerrando los issues #61 y #62.

## Cambios realizados

### CSV Google Workspace — issue #61 (29 columnas)
Genera una línea por docente con los campos requeridos:

| Col | Campo | Valor |
|-----|-------|-------|
| 1 | First Name | Nombre del docente |
| 2 | Last Name | Apellidos del docente |
| 3 | Email Address | email@fpvirtualaragon.es |
| 4 | Password | `Cambiam3!_` |
| 6 | Org Unit Path | `/Profesorado` |
| 8 | Recovery Email | Email personal del docente |
| 10 | Work Secondary Email | Email personal del docente |
| 17 | Employee ID | DNI del docente |
| 26 | Change Password at Next Sign-In | `TRUE` |
| 27 | New Status | `Active` |
| 29 | Advanced Protection Program | `FALSE` |

### CSV Moodle — issue #62 (29 columnas)
Mismo formato de 29 columnas que Google Workspace con la diferencia de:
- **Work Secondary Email** (col. 10): vacío
- **New Status** (col. 27): vacío

### Modal de exportación
- Botón **Cerrar y actualizar estado**: marca los docentes como procesados 
  (tick verde + fecha/hora) sin recargar la página
- Botón **Cerrar sin actualizar estado**: cierra sin modificar nada

## Tests
- 25 tests en `AltaPlataformaTest` cubriendo acceso, filtros, procesado 
  y formato exacto de ambos CSV (29 columnas Google y Moodle)
- Corrección: `orderBy('id')` → `orderBy('id_centro')` en `centro_docente`

## Cambios incluidos

### Issue #61 — Formato CSV Google Workspace
- El CSV de Google Workspace exporta **29 columnas** con el formato oficial
- Col 10 (Work Secondary Email): se rellena con el email personal del docente
- Col 27 (New Status [UPLOAD ONLY]): valor fijo `Active`
- Contraseña inicial: `Cambiam3!_` | Unidad organizativa: `/Profesorado`
- Col 8 (Recovery Email): email personal del docente

### Issue #62 — Formato CSV Moodle
- El CSV de Moodle exporta también **29 columnas** con el mismo formato que Google Workspace
- Col 10 (Work Secondary Email): vacía (Moodle no usa este campo)
- Col 27 (New Status [UPLOAD ONLY]): vacía (Moodle no usa este campo)
- Cabecera de descarga corregida (antes exportaba solo 4 columnas)

### Fixes panel admin
- El enlace **Alta Plataforma** aparece en la navegación **solo para el usuario admin**
- El admin puede acceder al panel (`/admin/alta-plataforma`, Ver Docentes, Ver Centros) **directamente desde su sesión web**, sin tener que iniciar sesión de admin por separado
- Corregido error `Attempt to read property "user" on null` en vistas del panel admin
- Corregido bug de tipos en la descarga CSV (los datos del docente ahora aparecen correctamente en el fichero descargado)

### Panel admin — acceso y roles
- Añadida columna `is_admin` (boolean) a la tabla `usuario`
- El enlace **Alta Plataforma** aparece en la navegación únicamente para usuarios con `is_admin = true`
- El admin accede a todo el panel (`Alta Plataforma`, `Ver Docentes`, `Ver Centros`) directamente desde su sesión web sin necesidad de un segundo login
- Para dar acceso de admin a un nuevo usuario basta con poner `is_admin = true` en su registro de la tabla `usuario`

### Estilos Alta Plataforma
- La página Alta Plataforma usa ahora el mismo CSS compartido que Ver Docentes y Ver Centros
- Misma tipografía, colores, tabla, botones y modales que el resto del panel admin


## Problema pendiente: gestión de roles para docentes

### Contexto
La app tiene dos tipos de entidades separadas:

- **`usuario`** → cuentas de acceso (centros educativos + admin). Login por campo `nombre` + contraseña.
- **`docentes`** → profesores del sistema. No tienen cuenta de acceso propia.

### El problema
Para que un docente pueda ser admin necesita una cuenta en la tabla `usuario`. Pero los docentes no tienen cuenta web — solo existen en la tabla `docentes` con su DNI y email personal.

### Lo que se intentó
Crear la cuenta automáticamente al pulsar "Hacer Admin" usando:

- `nombre` = `{Nombre} {Apellido}` del docente
- `contraseña` = su DNI
- `email` = su email personal de la tabla `centro_docente`

### Por qué se descartó
- El sistema de login usa el campo `nombre` como identificador, no el email — poco estándar y propenso a colisiones.
- No hay flujo claro para comunicar las credenciales al docente.
- Mezcla entidades distintas (`docentes` ↔ `usuario`) sin un diseño claro.

### Solución correcta (pendiente)
Antes de implementar esto hay que decidir:

- ¿El login de docentes-admin usará `email` o `nombre`?
- ¿Cómo se les comunica la contraseña inicial?
- ¿Se crea la cuenta manualmente o de forma automática?


## Issues relacionados
Closes #61
Closes #62
Parte de #59