### PR TITLE
fix: actualizar laravel-lang/http-statuses para evitar bloqueo por malware

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1861,16 +1861,16 @@
         },
         {
             "name": "laravel-lang/http-statuses",
-            "version": "3.10.3",
+            "version": "3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/http-statuses.git",
-                "reference": "32f9c3e9a93179ea6769844eaddfe8ae4cf3df63"
+                "reference": "6b563bfb5aa634494597ae559856650f9b68d027"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/http-statuses/zipball/32f9c3e9a93179ea6769844eaddfe8ae4cf3df63",
-                "reference": "32f9c3e9a93179ea6769844eaddfe8ae4cf3df63",
+                "url": "https://api.github.com/repos/Laravel-Lang/http-statuses/zipball/6b563bfb5aa634494597ae559856650f9b68d027",
+                "reference": "6b563bfb5aa634494597ae559856650f9b68d027",
                 "shasum": ""
             },
             "require": {
@@ -1910,7 +1910,7 @@
                     "homepage": "https://github.com/Laravel-Lang"
                 }
             ],
-            "description": "List of 127 languages for HTTP statuses",
+            "description": "Translation of HTTP statuses",
             "keywords": [
                 "http",
                 "lang",
@@ -1922,9 +1922,19 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/http-statuses/issues",
-                "source": "https://github.com/Laravel-Lang/http-statuses/tree/3.10.3"
+                "source": "https://github.com/Laravel-Lang/http-statuses/tree/3.13.1"
             },
-            "time": "2025-03-11T20:03:32+00:00"
+            "funding": [
+                {
+                    "url": "https://boosty.to/dragon-code",
+                    "type": "boosty"
+                },
+                {
+                    "url": "https://yoomoney.ru/to/410012608840929",
+                    "type": "yoomoney"
+                }
+            ],
+            "time": "2026-05-23T20:17:47+00:00"
         },
         {
             "name": "laravel-lang/json-fallback",
@@ -10863,5 +10873,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
 La 3.10.3 de `laravel-lang/http-statuses` está marcada como malware en Packagist, y `composer install --no-dev` abortaba (exit code 2) rompiendo el build de Docker. Se actualiza a la 3.13.1 (limpia, dentro de `^3.8`). 